### PR TITLE
Fixed redirect after user logout (Fixes #108)

### DIFF
--- a/wger/core/templates/template_features.html
+++ b/wger/core/templates/template_features.html
@@ -61,6 +61,8 @@
     <div class="container">
         {% block template %}{% endblock %}
     </div>
+    <div id="current-url" data-current-url="{{request_full_path}}"></div>
+    <div id="current-language" data-current-language="{{language.short_name}}"></div>
 </div>
 
 


### PR DESCRIPTION
looks like the ajax form submit code needs this in order to correctly redirect. I don't know whether current-language is useful to have there too but might prevent future similar mistakes.
