### PR TITLE
Ordered equipment alphabetically (Issue #100)

### DIFF
--- a/wger/exercises/views/equipment.py
+++ b/wger/exercises/views/equipment.py
@@ -134,5 +134,5 @@ class EquipmentOverviewView(WgerPermissionMixin, ListView):
         context['exercise_languages'] = load_item_languages(LanguageConfig.SHOW_ITEM_EXERCISES)
         for equipment in context['equipment_list']:
             equipment.name = _(equipment.name)
-        context['equipment_list'] = sorted(context['equipment_list'],key=lambda equipment: equipment.name)
+        context['equipment_list'] = sorted(context['equipment_list'], key=lambda e: e.name)
         return context


### PR DESCRIPTION
I made an attempt to solve issue #100.
After the changes in code, the software seems to be working fine on my
machine without any errors.

Files changed: wger\excercises\views\equipment.py

In this view file, I created a list with translated equipment names,
sorted it and passed it to the template.
