### PR TITLE
Deprecation warning context_processors

### DIFF
--- a/wger/utils/generic_views.py
+++ b/wger/utils/generic_views.py
@@ -21,7 +21,7 @@ from django.utils.translation import ugettext_lazy
 from django.contrib import messages
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.core.urlresolvers import reverse, reverse_lazy
-from django.core.context_processors import csrf
+from django.template.context_processors import csrf
 from django.views.generic.edit import ModelFormMixin
 from django.views.generic import TemplateView
 from django.http import HttpResponseRedirect, HttpResponseForbidden


### PR DESCRIPTION
A warning message is shown when starting the server:
```
wger/source/wger/utils/generic_views.py:24: RemovedInDjango110Warning:
django.core.context_processors is deprecated in favor of
django.template.context_processors.
  from django.core.context_processors import csrf
```