### PR TITLE
Use newer setuptools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 # Requirements for wger for production
 #
 
+setuptools>=18.5
 bleach
 django-bootstrap-breadcrumbs
 django-bower


### PR DESCRIPTION
With Python 2.7 and Python 3.4 newer setuptools required in order to work with html5lib.

From Travis-CI: setuptools 12.0.5 is installed but setuptools>=18.5 is required by set(['html5lib'])