### PR TITLE
Fix docker/apache docker API access

### DIFF
--- a/extras/docker/apache/wger.conf
+++ b/extras/docker/apache/wger.conf
@@ -9,6 +9,7 @@
     WSGIDaemonProcess wger python-path=/home/wger/src python-home=/home/wger/venv
     WSGIProcessGroup wger
     WSGIScriptAlias / /home/wger/src/wger/wsgi.py
+    WSGIPassAuthorization On
 
     Alias /static/ /home/wger/static/
     <Directory /home/wger/static>


### PR DESCRIPTION
At present the API doesn't work when using the docker wger/apache image.

This is because the ``WSGIPassAuthorization On`` apache directive isn't specified.

This can be found on the rest_framework documentation at the following URL

http://www.django-rest-framework.org/api-guide/authentication/#apache-mod_wsgi-specific-configuration