### PR TITLE
Adds configuring of allowing users to add new exercises and ingredients - fixes #382

### DIFF
--- a/wger/config/forms.py
+++ b/wger/config/forms.py
@@ -28,4 +28,5 @@ class UserCreateItemPermForm(forms.ModelForm):
     class Meta:
         model = UserCanCreate
         fields = ('ingredient_perm',
+                  'exercise_perm',
                   )

--- a/wger/config/forms.py
+++ b/wger/config/forms.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of wger Workout Manager.
+#
+# wger Workout Manager is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# wger Workout Manager is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+
+# Third Party
+from captcha.fields import ReCaptchaField
+from django import forms
+from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
+from django.utils.translation import ugettext as _
+
+#wger
+from wger.config.models import UserCanCreate
+
+class UserCreateItemPermForm(forms.ModelForm):
+    class Meta:
+        model = UserCanCreate
+        fields = ('ingredient_perm',
+                  )

--- a/wger/config/forms.py
+++ b/wger/config/forms.py
@@ -15,11 +15,7 @@
 # You should have received a copy of the GNU Affero General Public License
 
 # Third Party
-from captcha.fields import ReCaptchaField
 from django import forms
-from django.contrib.auth.models import User
-from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext as _
 
 # wger
 from wger.config.models import UserCanCreate

--- a/wger/config/forms.py
+++ b/wger/config/forms.py
@@ -21,8 +21,9 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext as _
 
-#wger
+# wger
 from wger.config.models import UserCanCreate
+
 
 class UserCreateItemPermForm(forms.ModelForm):
     class Meta:

--- a/wger/config/migrations/0002_usercancreate.py
+++ b/wger/config/migrations/0002_usercancreate.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('config', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='UserCanCreate',
+            fields=[
+                ('id', models.AutoField(auto_created=True,
+                                        primary_key=True,
+                                        serialize=False,
+                                        verbose_name='ID')),
+                ('ingredient_perm', models.CharField(choices=[('DENY', 'DENY - user cannot create new items'),
+                                                              ('REVIEW', 'REVIEW - user may submit item for approval'),
+                                                              ('ACCEPT', 'ACCEPT - user can create items without approval')],
+                                                     default='REVIEW', help_text='Allow user to submit new ingredient',
+                                                     max_length=6,
+                                                     verbose_name='Allow user to submit new ingredient')
+                 ),
+                ('exercise_perm', models.CharField(choices=[('DENY', 'DENY - user cannot create new items'),
+                                                            ('REVIEW', 'REVIEW - user may submit item for approval'),
+                                                            ('ACCEPT', 'ACCEPT - user can create items without approval')],
+                                                   default='REVIEW', help_text='Allow user to submit new exercise',
+                                                   max_length=6, verbose_name='Allow user to submit new exercise')
+                 ),
+                ('user', models.OneToOneField(editable=False,
+                                              on_delete=django.db.models.deletion.CASCADE,
+                                              to=settings.AUTH_USER_MODEL)
+                 ),
+            ],
+        ),
+        migrations.AlterField(
+            model_name='languageconfig',
+            name='item',
+            field=models.CharField(choices=[('1', 'Exercises'),
+                                            ('2', 'Ingredients')],
+                                   editable=False,
+                                   max_length=2),
+        ),
+    ]

--- a/wger/config/models.py
+++ b/wger/config/models.py
@@ -183,3 +183,17 @@ class UserCanCreate(models.Model):
                                        choices=USER_PERMISSION_CHOICES,
                                        default=REVIEW,
                                        )
+
+    def ingredient_create_perm(self):
+        if is_any_gym_admin(self.user):
+            return True
+        elif self.ingredient_perm == 'REVIEW' or self.ingredient_perm == 'ACCEPT':
+            return True
+        else:
+            return False
+
+    def ingredient_needs_review(self):
+        if self.ingredient_perm =="ACCEPT":
+            return False
+        else:
+            return True

--- a/wger/config/models.py
+++ b/wger/config/models.py
@@ -161,6 +161,7 @@ class GymConfig(models.Model):
 
         return super(GymConfig, self).save(*args, **kwargs)
 
+
 @python_2_unicode_compatible
 class UserCanCreate(models.Model):
     user = models.OneToOneField(User,

--- a/wger/config/models.py
+++ b/wger/config/models.py
@@ -19,6 +19,7 @@
 import logging
 
 # Third Party
+from django.contrib.auth.models import User
 from django.core.cache import cache
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
@@ -159,3 +160,26 @@ class GymConfig(models.Model):
                         logger.debug('Creating GymUserConfig for user {0}'.format(user.username))
 
         return super(GymConfig, self).save(*args, **kwargs)
+
+@python_2_unicode_compatible
+class UserCanCreate(models.Model):
+    user = models.OneToOneField(User,
+                                editable=False)
+    '''
+    The user
+    '''
+    DENY = 'DENY'
+    REVIEW = 'REVIEW'
+    ACCEPT = 'ACCEPT'
+    USER_PERMISSION_CHOICES = (
+        (DENY, 'DENY - user cannot create new items'),
+        (REVIEW, 'REVIEW - user may submit item for approval'),
+        (ACCEPT, 'ACCCEPT - user can create items without approval'),
+    )
+
+    ingredient_perm = models.CharField(max_length=6,
+                                       verbose_name=_('Allow user to submit new ingredient'),
+                                       help_text=_('Allow user to submit new ingredient'),
+                                       choices=USER_PERMISSION_CHOICES,
+                                       default=REVIEW,
+                                       )

--- a/wger/config/models.py
+++ b/wger/config/models.py
@@ -174,7 +174,7 @@ class UserCanCreate(models.Model):
     USER_PERMISSION_CHOICES = (
         (DENY, 'DENY - user cannot create new items'),
         (REVIEW, 'REVIEW - user may submit item for approval'),
-        (ACCEPT, 'ACCCEPT - user can create items without approval'),
+        (ACCEPT, 'ACCEPT - user can create items without approval'),
     )
 
     ingredient_perm = models.CharField(max_length=6,

--- a/wger/config/models.py
+++ b/wger/config/models.py
@@ -219,3 +219,9 @@ class UserCanCreate(models.Model):
             return False
         else:
             return True
+
+    def __str__(self):
+        '''
+        Return a more human-readable respresentation
+        '''
+        return u"Item creation settings for user {0}".format(self.user)

--- a/wger/config/models.py
+++ b/wger/config/models.py
@@ -184,6 +184,13 @@ class UserCanCreate(models.Model):
                                        default=REVIEW,
                                        )
 
+    exercise_perm = models.CharField(max_length=6,
+                                     verbose_name=_('Allow user to submit new exercise'),
+                                     help_text=_('Allow user to submit new exercise'),
+                                     choices=USER_PERMISSION_CHOICES,
+                                     default=REVIEW,
+                                     )
+
     def ingredient_create_perm(self):
         if is_any_gym_admin(self.user):
             return True
@@ -193,7 +200,21 @@ class UserCanCreate(models.Model):
             return False
 
     def ingredient_needs_review(self):
-        if self.ingredient_perm =="ACCEPT":
+        if self.ingredient_perm == 'ACCEPT':
+            return False
+        else:
+            return True
+
+    def create_exercise(self):
+        if is_any_gym_admin(self.user):
+            return True
+        elif self.exercise_perm == 'REVIEW' or self.exercise_perm == 'ACCEPT':
+            return True
+        else:
+            return False
+
+    def exercise_needs_review(self):
+        if self.exercise_perm == 'ACCEPT':
             return False
         else:
             return True

--- a/wger/config/signals.py
+++ b/wger/config/signals.py
@@ -50,6 +50,7 @@ def init_language_config(sender, instance, created, **kwargs):
                         config.show = False
                     config.save()
 
+
 @disable_for_loaddata
 def create_user_item_perm(sender, instance, created, **kwargs):
     '''

--- a/wger/config/signals.py
+++ b/wger/config/signals.py
@@ -16,12 +16,15 @@
 
 
 # Third Party
+from django.contrib.auth.models import User
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
 # wger
 from wger.config.models import LanguageConfig
 from wger.core.models import Language
+from wger.config.models import UserCanCreate
+from wger.utils.helpers import disable_for_loaddata
 
 
 @receiver(post_save, sender=Language)
@@ -46,3 +49,14 @@ def init_language_config(sender, instance, created, **kwargs):
                     else:
                         config.show = False
                     config.save()
+
+@disable_for_loaddata
+def create_user_item_perm(sender, instance, created, **kwargs):
+    '''
+    Every new user gets a set of permissions for submitting new
+    items such as ingredients and exercises
+    '''
+    if created:
+        UserCanCreate.objects.create(user=instance)
+
+post_save.connect(create_user_item_perm, sender=User)

--- a/wger/config/views/config.py
+++ b/wger/config/views/config.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of wger Workout Manager.
+#
+# wger Workout Manager is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# wger Workout Manager is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+
+# Standard Library
+import logging
+
+# Third Party
+from django.contrib.auth.mixins import (
+    LoginRequiredMixin,
+    PermissionRequiredMixin
+)
+from django.core.urlresolvers import reverse
+from django.contrib.auth import authenticate
+from django.contrib.auth.models import User
+from django.http import HttpResponseForbidden, HttpResponseRedirect
+from django.utils.translation import (
+    ugettext as _,
+    ugettext_lazy
+)
+from django.views.generic import UpdateView
+
+# wger
+from wger.config.models import UserCanCreate
+from wger.config.forms import UserCreateItemPermForm
+from wger.utils.generic_views import (
+    WgerFormMixin,
+    WgerMultiplePermissionRequiredMixin
+)
+
+
+logger = logging.getLogger(__name__)
+
+class UserItemPermView(WgerFormMixin,
+                       LoginRequiredMixin,
+                       WgerMultiplePermissionRequiredMixin,
+                       UpdateView):
+
+    model = UserCanCreate
+    title = ugettext_lazy('Permission to create new items')
+    form_class = UserCreateItemPermForm
+    permission_required = ('gym.manage_gym', 'gym.manage_gyms')
+
+    def dispatch(self, request, *args, **kwargs):
+        '''
+        Check permissions
+
+        - Managers can edit permissions for members of their own gym
+        - General managers can edit permissions for every member
+        '''
+        user = request.user
+        if not user.is_authenticated():
+            return HttpResponseForbidden()
+
+        if user.has_perm('gym.manage_gym') \
+               and not user.has_perm('gym.manage_gyms') \
+               and user.userprofile.gym != self.get_object().userprofile.gym:
+            return HttpResponseForbidden()
+
+        return super(UserItemPermView, self).dispatch(request, *args, **kwargs)
+
+    def get_success_url(self):
+        return reverse('core:user:overview', kwargs={'pk': self.kwargs['pk']})
+
+    def get_context_data(self, **kwargs):
+        context = super(UserItemPermView, self).get_context_data(**kwargs)
+        context['form_action'] = reverse('core:user:create-item-perm',
+                                         kwargs={'pk': self.object.id})
+        return context

--- a/wger/config/views/config.py
+++ b/wger/config/views/config.py
@@ -18,18 +18,10 @@
 import logging
 
 # Third Party
-from django.contrib.auth.mixins import (
-    LoginRequiredMixin,
-    PermissionRequiredMixin
-)
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.urlresolvers import reverse
-from django.contrib.auth import authenticate
-from django.contrib.auth.models import User
-from django.http import HttpResponseForbidden, HttpResponseRedirect
-from django.utils.translation import (
-    ugettext as _,
-    ugettext_lazy
-)
+from django.http import HttpResponseForbidden
+from django.utils.translation import ugettext_lazy
 from django.views.generic import UpdateView
 
 # wger

--- a/wger/config/views/config.py
+++ b/wger/config/views/config.py
@@ -43,6 +43,7 @@ from wger.utils.generic_views import (
 
 logger = logging.getLogger(__name__)
 
+
 class UserItemPermView(WgerFormMixin,
                        LoginRequiredMixin,
                        WgerMultiplePermissionRequiredMixin,
@@ -65,8 +66,8 @@ class UserItemPermView(WgerFormMixin,
             return HttpResponseForbidden()
 
         if user.has_perm('gym.manage_gym') \
-               and not user.has_perm('gym.manage_gyms') \
-               and user.userprofile.gym != self.get_object().userprofile.gym:
+            and not user.has_perm('gym.manage_gyms') \
+                and user.userprofile.gym != self.get_object().userprofile.gym:
             return HttpResponseForbidden()
 
         return super(UserItemPermView, self).dispatch(request, *args, **kwargs)

--- a/wger/core/fixtures/test-user-data.json
+++ b/wger/core/fixtures/test-user-data.json
@@ -1413,192 +1413,217 @@
         "pk": 1,
         "model": "config.usercancreate",
         "fields": {
-             "user": 1,
-             "ingredient_perm": "ACCEPT"
+            "user": 1,
+           	"ingredient_perm": "ACCEPT",
+			"exercise_perm": "ACCEPT"
+
         }
     },
 	{
         "pk": 2,
         "model": "config.usercancreate",
         "fields": {
-             "user": 2,
-             "ingredient_perm": "REVIEW"
+            "user": 2,
+            "ingredient_perm": "REVIEW",
+			"exercise_perm": "REVIEW"
         }
     },
 	{
         "pk": 3,
         "model": "config.usercancreate",
         "fields": {
-             "user": 3,
-             "ingredient_perm": "REVIEW"
+            "user": 3,
+            "ingredient_perm": "REVIEW",
+			"exercise_perm": "REVIEW"
         }
     },
 	{
         "pk": 4,
         "model": "config.usercancreate",
         "fields": {
-             "user": 4,
-             "ingredient_perm": "ACCEPT"
+            "user": 4,
+            "ingredient_perm": "ACCEPT",
+			"exercise_perm": "ACCEPT"
         }
     },
 	{
         "pk": 5,
         "model": "config.usercancreate",
         "fields": {
-             "user": 5,
-             "ingredient_perm": "ACCEPT"
+            "user": 5,
+            "ingredient_perm": "ACCEPT",
+			"exercise_perm": "ACCEPT"
         }
     },
 	{
         "pk": 6,
         "model": "config.usercancreate",
         "fields": {
-             "user": 6,
-             "ingredient_perm": "ACCEPT"
+            "user": 6,
+            "ingredient_perm": "ACCEPT",
+			"exercise_perm": "ACCEPT"
         }
     },
 	{
         "pk": 7,
         "model": "config.usercancreate",
         "fields": {
-             "user": 7,
-             "ingredient_perm": "ACCEPT"
+            "user": 7,
+            "ingredient_perm": "ACCEPT",
+			"exercise_perm": "ACCEPT"
         }
     },
 	{
         "pk": 8,
         "model": "config.usercancreate",
         "fields": {
-             "user": 8,
-             "ingredient_perm": "ACCEPT"
+            "user": 8,
+            "ingredient_perm": "ACCEPT",
+			"exercise_perm": "ACCEPT"
         }
     },
 	{
         "pk": 9,
         "model": "config.usercancreate",
         "fields": {
-             "user": 9,
-             "ingredient_perm": "ACCEPT"
+            "user": 9,
+            "ingredient_perm": "ACCEPT",
+			"exercise_perm": "ACCEPT"
         }
     },
 	{
         "pk": 10,
         "model": "config.usercancreate",
         "fields": {
-             "user": 10,
-             "ingredient_perm": "ACCEPT"
+            "user": 10,
+            "ingredient_perm": "ACCEPT",
+			"exercise_perm": "ACCEPT"
         }
     },
 	{
         "pk": 11,
         "model": "config.usercancreate",
         "fields": {
-             "user": 11,
-             "ingredient_perm": "ACCEPT"
+            "user": 11,
+            "ingredient_perm": "ACCEPT",
+			"exercise_perm": "ACCEPT"
         }
     },
 	{
         "pk": 12,
         "model": "config.usercancreate",
         "fields": {
-             "user": 12,
-             "ingredient_perm": "ACCEPT"
+            "user": 12,
+            "ingredient_perm": "ACCEPT",
+			"exercise_perm": "ACCEPT"
         }
     },
 	{
         "pk": 13,
         "model": "config.usercancreate",
         "fields": {
-             "user": 13,
-             "ingredient_perm": "ACCEPT"
+            "user": 13,
+            "ingredient_perm": "ACCEPT",
+			"exercise_perm": "ACCEPT"
         }
     },
 	{
         "pk": 14,
         "model": "config.usercancreate",
         "fields": {
-             "user": 14,
-             "ingredient_perm": "REVIEW"
+            "user": 14,
+            "ingredient_perm": "REVIEW",
+			"exercise_perm": "REVIEW"
         }
     },
 	{
         "pk": 15,
         "model": "config.usercancreate",
         "fields": {
-             "user": 15,
-             "ingredient_perm": "REVIEW"
+            "user": 15,
+            "ingredient_perm": "REVIEW",
+			"exercise_perm": "REVIEW"
         }
     },
 	{
         "pk": 16,
         "model": "config.usercancreate",
         "fields": {
-             "user": 16,
-             "ingredient_perm": "REVIEW"
+            "user": 16,
+            "ingredient_perm": "REVIEW",
+			"exercise_perm": "REVIEW"
         }
     },
 	{
         "pk": 17,
         "model": "config.usercancreate",
         "fields": {
-             "user": 17,
-             "ingredient_perm": "REVIEW"
+            "user": 17,
+            "ingredient_perm": "REVIEW",
+			"exercise_perm": "REVIEW"
         }
     },
 	{
         "pk": 18,
         "model": "config.usercancreate",
         "fields": {
-             "user": 18,
-             "ingredient_perm": "REVIEW"
+            "user": 18,
+            "ingredient_perm": "REVIEW",
+			"exercise_perm": "REVIEW"
         }
     },
 	{
         "pk": 19,
         "model": "config.usercancreate",
         "fields": {
-             "user": 19,
-             "ingredient_perm": "REVIEW"
+            "user": 19,
+            "ingredient_perm": "REVIEW",
+			"exercise_perm": "REVIEW"
         }
     },
 	{
         "pk": 20,
         "model": "config.usercancreate",
         "fields": {
-             "user": 20,
-             "ingredient_perm": "REVIEW"
+            "user": 20,
+            "ingredient_perm": "REVIEW",
+			"exercise_perm": "REVIEW"
         }
     },
 	{
         "pk": 21,
         "model": "config.usercancreate",
         "fields": {
-             "user": 21,
-             "ingredient_perm": "REVIEW"
+			"user": 21,
+            "ingredient_perm": "REVIEW",
+			"exercise_perm": "REVIEW"
         }
     },
 	{
         "pk": 22,
         "model": "config.usercancreate",
         "fields": {
-             "user": 22,
-             "ingredient_perm": "REVIEW"
+            "user": 22,
+            "ingredient_perm": "REVIEW",
+			"exercise_perm": "REVIEW"
         }
     },
 	{
         "pk": 23,
         "model": "config.usercancreate",
         "fields": {
-             "user": 23,
-             "ingredient_perm": "REVIEW"
+            "user": 23,
+            "ingredient_perm": "REVIEW",
+			"exercise_perm": "REVIEW"
         }
     },
 	{
         "pk": 24,
         "model": "config.usercancreate",
         "fields": {
-             "user": 24,
-             "ingredient_perm": "REVIEW"
+            "user": 24,
+            "ingredient_perm": "REVIEW",
+			"exercise_perm": "REVIEW"
         }
     }
 ]

--- a/wger/core/fixtures/test-user-data.json
+++ b/wger/core/fixtures/test-user-data.json
@@ -1408,5 +1408,197 @@
             "last_activity": null,
             "user_id": 24
         }
+    },
+	{
+        "pk": 1,
+        "model": "config.usercancreate",
+        "fields": {
+             "user": 1,
+             "ingredient_perm": "ACCEPT"
+        }
+    },
+	{
+        "pk": 2,
+        "model": "config.usercancreate",
+        "fields": {
+             "user": 2,
+             "ingredient_perm": "REVIEW"
+        }
+    },
+	{
+        "pk": 3,
+        "model": "config.usercancreate",
+        "fields": {
+             "user": 3,
+             "ingredient_perm": "REVIEW"
+        }
+    },
+	{
+        "pk": 4,
+        "model": "config.usercancreate",
+        "fields": {
+             "user": 4,
+             "ingredient_perm": "ACCEPT"
+        }
+    },
+	{
+        "pk": 5,
+        "model": "config.usercancreate",
+        "fields": {
+             "user": 5,
+             "ingredient_perm": "ACCEPT"
+        }
+    },
+	{
+        "pk": 6,
+        "model": "config.usercancreate",
+        "fields": {
+             "user": 6,
+             "ingredient_perm": "ACCEPT"
+        }
+    },
+	{
+        "pk": 7,
+        "model": "config.usercancreate",
+        "fields": {
+             "user": 7,
+             "ingredient_perm": "ACCEPT"
+        }
+    },
+	{
+        "pk": 8,
+        "model": "config.usercancreate",
+        "fields": {
+             "user": 8,
+             "ingredient_perm": "ACCEPT"
+        }
+    },
+	{
+        "pk": 9,
+        "model": "config.usercancreate",
+        "fields": {
+             "user": 9,
+             "ingredient_perm": "ACCEPT"
+        }
+    },
+	{
+        "pk": 10,
+        "model": "config.usercancreate",
+        "fields": {
+             "user": 10,
+             "ingredient_perm": "ACCEPT"
+        }
+    },
+	{
+        "pk": 11,
+        "model": "config.usercancreate",
+        "fields": {
+             "user": 11,
+             "ingredient_perm": "ACCEPT"
+        }
+    },
+	{
+        "pk": 12,
+        "model": "config.usercancreate",
+        "fields": {
+             "user": 12,
+             "ingredient_perm": "ACCEPT"
+        }
+    },
+	{
+        "pk": 13,
+        "model": "config.usercancreate",
+        "fields": {
+             "user": 13,
+             "ingredient_perm": "ACCEPT"
+        }
+    },
+	{
+        "pk": 14,
+        "model": "config.usercancreate",
+        "fields": {
+             "user": 14,
+             "ingredient_perm": "REVIEW"
+        }
+    },
+	{
+        "pk": 15,
+        "model": "config.usercancreate",
+        "fields": {
+             "user": 15,
+             "ingredient_perm": "REVIEW"
+        }
+    },
+	{
+        "pk": 16,
+        "model": "config.usercancreate",
+        "fields": {
+             "user": 16,
+             "ingredient_perm": "REVIEW"
+        }
+    },
+	{
+        "pk": 17,
+        "model": "config.usercancreate",
+        "fields": {
+             "user": 17,
+             "ingredient_perm": "REVIEW"
+        }
+    },
+	{
+        "pk": 18,
+        "model": "config.usercancreate",
+        "fields": {
+             "user": 18,
+             "ingredient_perm": "REVIEW"
+        }
+    },
+	{
+        "pk": 19,
+        "model": "config.usercancreate",
+        "fields": {
+             "user": 19,
+             "ingredient_perm": "REVIEW"
+        }
+    },
+	{
+        "pk": 20,
+        "model": "config.usercancreate",
+        "fields": {
+             "user": 20,
+             "ingredient_perm": "REVIEW"
+        }
+    },
+	{
+        "pk": 21,
+        "model": "config.usercancreate",
+        "fields": {
+             "user": 21,
+             "ingredient_perm": "REVIEW"
+        }
+    },
+	{
+        "pk": 22,
+        "model": "config.usercancreate",
+        "fields": {
+             "user": 22,
+             "ingredient_perm": "REVIEW"
+        }
+    },
+	{
+        "pk": 23,
+        "model": "config.usercancreate",
+        "fields": {
+             "user": 23,
+             "ingredient_perm": "REVIEW"
+        }
+    },
+	{
+        "pk": 24,
+        "model": "config.usercancreate",
+        "fields": {
+             "user": 24,
+             "ingredient_perm": "REVIEW"
+        }
     }
 ]

--- a/wger/core/fixtures/users.json
+++ b/wger/core/fixtures/users.json
@@ -51,5 +51,13 @@
             "last_activity": null,
             "user_id": 1
         }
+    },
+    {
+        "pk": 1,
+        "model": "config.usercancreate",
+        "fields": {
+             "user": 1,
+             "ingredient_perm": "ACCEPT"
+        }
     }
 ]

--- a/wger/core/fixtures/users.json
+++ b/wger/core/fixtures/users.json
@@ -56,8 +56,9 @@
         "pk": 1,
         "model": "config.usercancreate",
         "fields": {
-             "user": 1,
-             "ingredient_perm": "ACCEPT"
+			"user": 1,
+			"ingredient_perm": "ACCEPT",
+			"exercise_perm": "ACCEPT"
         }
     }
 ]

--- a/wger/core/templates/navigation.html
+++ b/wger/core/templates/navigation.html
@@ -55,7 +55,7 @@
                                 <li><a href="{% url 'exercise:exercise:overview' %}">{% trans "Exercises" %}</a></li>
                                 <li><a href="{% url 'exercise:muscle:overview' %}">{% trans "Muscle overview" %}</a></li>
                                 <li><a href="{% url 'exercise:equipment:overview' %}">{% trans "Equipment overview" %}</a></li>
-                                {% if user.is_authenticated and not user.userprofile.is_temporary and not trainer_identity %}
+                                {% if user.is_authenticated and not user.userprofile.is_temporary and not trainer_identity and user.usercancreate.create_exercise %}
                                 <li class="divider"></li>
                                 <li><a href="{% url 'exercise:exercise:add' %}">{% trans "Add new exercise" %}</a><li>
                                 {% endif %}

--- a/wger/core/templates/user/overview.html
+++ b/wger/core/templates/user/overview.html
@@ -486,6 +486,34 @@
         </td>
     </tr>
 </table>
+
+{#            #}
+{# Permission #}
+{#            #}
+{% if perms.gym.manage_gyms or perms.gym.manage_gym %}
+<div class="btn-group pull-right">
+    <button type="button" class="btn btn-default dropdown-toggle btn-xs" data-toggle="dropdown">
+        {% trans "Actions" %} <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" role="menu">
+
+        <li>
+            <a href="{% url 'core:user:create-item-perm' current_user.pk %}" class="wger-modal-dialog">{% trans "Edit"%}</a>
+        </li>
+    </ul>
+</div>
+{% endif %}
+
+<h4>{% trans "Permissions" %}</h4>
+<table class="table">
+    <tr>
+        <td>{% trans 'Can create new ingredients' %}</td>
+        <td style="text-align: right;">
+            {{ current_user.usercancreate.ingredient_permission }}
+        </td>
+    </tr>
+</table>
+
 {% endblock %}
 
 

--- a/wger/core/templates/user/overview.html
+++ b/wger/core/templates/user/overview.html
@@ -507,9 +507,15 @@
 <h4>{% trans "Permissions" %}</h4>
 <table class="table">
     <tr>
-        <td>{% trans 'Can create new ingredients' %}</td>
+        <td>{% trans 'Can create ingredients' %}</td>
         <td style="text-align: right;">
-            {{ current_user.usercancreate.ingredient_permission }}
+            {% if current_user.usercancreate.ingredient_create_perm and not current_user.usercancreate.ingredient_needs_review %}
+				{% trans "Accept" %}
+			{% elif current_user.usercancreate.ingredient_create_perm and current_user.usercancreate.ingredient_needs_review %}
+				{% trans "Review" %}
+			{% else %}
+				{% trans "Denied" %}
+			{% endif %}
         </td>
     </tr>
 </table>

--- a/wger/core/templates/user/overview.html
+++ b/wger/core/templates/user/overview.html
@@ -518,6 +518,17 @@
 			{% endif %}
         </td>
     </tr>
+	<tr>
+		<td>{% trans 'Can create exercises' %}</td>
+		<td style="text-align: right;">
+		{% if current_user.usercancreate.create_exercise and not current_user.usercancreate.exercise_needs_review %}
+			{% trans "Accept" %}
+		{% elif current_user.usercancreate.create_exercise and current_user.usercancreate.exercise_needs_review %}
+			{% trans "Review" %}
+		{% else %}
+			{% trans "Denied" %}
+		{% endif %}
+	</tr>
 </table>
 
 {% endblock %}

--- a/wger/core/urls.py
+++ b/wger/core/urls.py
@@ -33,6 +33,7 @@ from wger.core.views import (
     user,
     weight_units
 )
+from wger.config.views import config
 
 
 # sub patterns for languages
@@ -98,6 +99,10 @@ patterns_user = [
     url(r'^list',
         user.UserListView.as_view(),
         name='list'),
+    url(r'^(?P<pk>\d+)/create-item-perm',
+        config.UserItemPermView.as_view(),
+        name='create-item-perm'),
+        
 
     # Password reset is implemented by Django, no need to cook our own soup here
     # (besides the templates)

--- a/wger/core/urls.py
+++ b/wger/core/urls.py
@@ -102,7 +102,7 @@ patterns_user = [
     url(r'^(?P<pk>\d+)/create-item-perm',
         config.UserItemPermView.as_view(),
         name='create-item-perm'),
-        
+
 
     # Password reset is implemented by Django, no need to cook our own soup here
     # (besides the templates)

--- a/wger/exercises/models.py
+++ b/wger/exercises/models.py
@@ -342,7 +342,7 @@ class Exercise(AbstractSubmissionModel, AbstractLicenseModel, models.Model):
                 self.license_authro = request.get_host().split(':')[0]
 
             subject = _('New user submitted exercise')
-            message = _(u'The user {0} submitted a new exercise "{1}".').format(
+            message = _(u'The user {0} submitted a new exercise "{1}".  Review not required.').format(
                 request.user.username, self.name)
             mail.mail_admins(six.text_type(subject),
                              six.text_type(message),
@@ -352,7 +352,7 @@ class Exercise(AbstractSubmissionModel, AbstractLicenseModel, models.Model):
                 self.license_author = request.user.username
 
             subject = _('New user submitted exercise - approval pending')
-            message = _(u'The user {0} submitted a new exercise "{1}".').format(
+            message = _(u'The user {0} submitted a new exercise "{1}" and requires review.').format(
                 request.user.username, self.name)
             mail.mail_admins(six.text_type(subject),
                              six.text_type(message),

--- a/wger/exercises/models.py
+++ b/wger/exercises/models.py
@@ -336,11 +336,22 @@ class Exercise(AbstractSubmissionModel, AbstractLicenseModel, models.Model):
             self.status = self.STATUS_ACCEPTED
             if not self.license_author:
                 self.license_author = request.get_host().split(':')[0]
+        elif not request.user.usercancreate.exercise_needs_review():
+            self.status = self.STATUS_ACCEPTED
+            if not self.license_author:
+                self.license_authro = request.get_host().split(':')[0]
+
+            subject = _('New user submitted exercise')
+            message = _(u'The user {0} submitted a new exercise "{1}".').format(
+                request.user.username, self.name)
+            mail.mail_admins(six.text_type(subject),
+                             six.text_type(message),
+                             fail_silently=True)
         else:
             if not self.license_author:
                 self.license_author = request.user.username
 
-            subject = _('New user submitted exercise')
+            subject = _('New user submitted exercise - approval pending')
             message = _(u'The user {0} submitted a new exercise "{1}".').format(
                 request.user.username, self.name)
             mail.mail_admins(six.text_type(subject),

--- a/wger/exercises/models.py
+++ b/wger/exercises/models.py
@@ -342,8 +342,8 @@ class Exercise(AbstractSubmissionModel, AbstractLicenseModel, models.Model):
                 self.license_authro = request.get_host().split(':')[0]
 
             subject = _('New user submitted exercise')
-            message = _(u'The user {0} submitted a new exercise "{1}".  Review not required.').format(
-                request.user.username, self.name)
+            message = _(u'The user {0} submitted a new exercise "{1}".  Review not required.'
+                        ).format(request.user.username, self.name)
             mail.mail_admins(six.text_type(subject),
                              six.text_type(message),
                              fail_silently=True)

--- a/wger/exercises/templates/exercise/form.html
+++ b/wger/exercises/templates/exercise/form.html
@@ -5,8 +5,12 @@
 <p><strong>{% blocktrans %}Thank you for submitting an exercise. This is much
 appreciated!{% endblocktrans %}</strong></p>
 
+{% if request.user.usercancreate.exercise_needs_review %}
 <p>{% blocktrans %}After you submit the form, the administrators will be notified.
 Once it is reviewed, it will be added to the database. Till this happens,
 it will not be visible in the overview or the search. In case you added your email
 when you registered, you will get notified when the process is completed successfully.{% endblocktrans %}</p>
+{% elif not request.user.usercancreate.exercise_needs_review %}
+<p>{% blocktrans %}After you submit the form, it will be added to the database. The administrators will be notified that a new exercise has been submitted, but a review is not required before it is visible.{% endblocktrans %}</p>
+{% endif %}
 {% endif %}

--- a/wger/exercises/templates/exercise/overview.html
+++ b/wger/exercises/templates/exercise/overview.html
@@ -117,10 +117,17 @@ $(document).ready(function() {
 
 
 {% block options %}
-    {% if user.is_authenticated and not user.userprofile.is_temporary %}
+    {% if user.is_authenticated and user.usercancreate.create_exercise and not user.userprofile.is_temporary %}
         <a href="{% url 'exercise:exercise:add' %}" class="btn btn-success btn-sm">
             {% trans "Add new exercise" %}
         </a>
+	{% elif user.is_authenticated and not usercancreate.create_exercise and not user.userprofile.is_temporary %}
+		<a href="#" class="btn btn-success btn-sm disabled">
+			{% trans "Add new exercise" %}<br>
+			<small>
+			{% trans "You do not have permission to do this" %}
+			</small>
+		</a>
     {% else %}
         <a href="#" class="btn btn-success btn-sm disabled">
             {% trans "Add new exercise" %}<br>

--- a/wger/exercises/views/exercises.py
+++ b/wger/exercises/views/exercises.py
@@ -251,9 +251,9 @@ class ExerciseAddView(ExercisesEditAddView, LoginRequiredMixin, CreateView):
 
     def dispatch(self, request, *args, **kwargs):
         '''
-        Demo users can't submit exercises
+        Demo users and users without permission can't submit exercises
         '''
-        if request.user.userprofile.is_temporary:
+        if request.user.userprofile.is_temporary or not request.user.usercancreate.create_exercise():
             return HttpResponseForbidden()
 
         return super(ExerciseAddView, self).dispatch(request, *args, **kwargs)

--- a/wger/exercises/views/exercises.py
+++ b/wger/exercises/views/exercises.py
@@ -253,7 +253,8 @@ class ExerciseAddView(ExercisesEditAddView, LoginRequiredMixin, CreateView):
         '''
         Demo users and users without permission can't submit exercises
         '''
-        if request.user.userprofile.is_temporary or not request.user.usercancreate.create_exercise():
+        if request.user.userprofile.is_temporary \
+           or not request.user.usercancreate.create_exercise():
             return HttpResponseForbidden()
 
         return super(ExerciseAddView, self).dispatch(request, *args, **kwargs)

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -435,7 +435,7 @@ class Ingredient(AbstractSubmissionModel, AbstractLicenseModel, models.Model):
 
             # Send email to administrator
             subject = _('New user submitted ingredient - no action needed')
-            message = _(u'''The {0} submitted a new ingredient "{1}".  No action needed.'''.format(
+            message = _(u'''The user {0} submitted a new ingredient "{1}".  No action needed.'''.format(
                 request.user.username, self.name))
             mail.mail_admins(subject,
                              message,

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -432,7 +432,7 @@ class Ingredient(AbstractSubmissionModel, AbstractLicenseModel, models.Model):
             self.status = Ingredient.STATUS_ACCEPTED
             if not self.license_author:
                 self.license_author = request.user.username
-                
+
             # Send email to administrator
             subject = _('New user submitted ingredient - no action needed')
             message = _(u'''The {0} submitted a new ingredient "{1}".  No action needed.'''.format(

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -428,6 +428,18 @@ class Ingredient(AbstractSubmissionModel, AbstractLicenseModel, models.Model):
             self.status = Ingredient.STATUS_ACCEPTED
             if not self.license_author:
                 self.license_author = request.get_host().split(':')[0]
+        elif not request.user.usercancreate.ingredient_needs_review():
+            self.status = Ingredient.STATUS_ACCEPTED
+            if not self.license_author:
+                self.license_author = request.user.username
+                
+            # Send email to administrator
+            subject = _('New user submitted ingredient - no action needed')
+            message = _(u'''The {0} submitted a new ingredient "{1}".  No action needed.'''.format(
+                request.user.username, self.name))
+            mail.mail_admins(subject,
+                             message,
+                             fail_silently=True)
         else:
             if not self.license_author:
                 self.license_author = request.user.username

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -435,8 +435,8 @@ class Ingredient(AbstractSubmissionModel, AbstractLicenseModel, models.Model):
 
             # Send email to administrator
             subject = _('New user submitted ingredient - no action needed')
-            message = _(u'''The user {0} submitted a new ingredient "{1}".  No action needed.'''.format(
-                request.user.username, self.name))
+            message = _(u'''The user {0} submitted a new ingredient "{1}".  No action needed.'''
+                        .format(request.user.username, self.name))
             mail.mail_admins(subject,
                              message,
                              fail_silently=True)

--- a/wger/nutrition/templates/ingredient/overview.html
+++ b/wger/nutrition/templates/ingredient/overview.html
@@ -77,10 +77,17 @@
 {# Options #}
 {#         #}
 {% block options %}
-    {% if user.is_authenticated and not user.userprofile.is_temporary %}
+    {% if user.is_authenticated and user.usercancreate.ingredient_create_perm and not user.userprofile.is_temporary %}
         <a href="{% url 'nutrition:ingredient:add' %}"
            class="btn btn-success btn-sm">
             {% trans "Add ingredient" %}
+        </a>
+	{% elif user.is_authenticated and not usercancreate.ingredient_create_perm and not user.userprofile.is_temporary %}
+		<a href="#" class="btn btn-success btn-sm disabled">
+            {% trans "Add ingredient" %}<br>
+            <small>
+                {% trans "You do not have permission to do this" %}
+            </small>
         </a>
     {% else %}
         <a href="#" class="btn btn-success btn-sm disabled">

--- a/wger/nutrition/templates/ingredient/overview.html
+++ b/wger/nutrition/templates/ingredient/overview.html
@@ -93,7 +93,7 @@
         <a href="#" class="btn btn-success btn-sm disabled">
             {% trans "Add ingredient" %}<br>
             <small>
-                {% trans "Only registered users can do this" %}
+            	{% trans "Only registered users can do this" %}
             </small>
         </a>
     {% endif %}

--- a/wger/nutrition/views/ingredient.py
+++ b/wger/nutrition/views/ingredient.py
@@ -203,9 +203,11 @@ class IngredientCreateView(IngredientMixin, CreateView):
 
     def dispatch(self, request, *args, **kwargs):
         '''
-        Demo users can't submit ingredients
+        Demo users and users without permission can't submit ingredients
         '''
         if request.user.userprofile.is_temporary:
+            return HttpResponseForbidden()
+        if not request.user.usercancreate.ingredient_create_perm():
             return HttpResponseForbidden()
         return super(IngredientCreateView, self).dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
Adds settings to let users add ingredients and exercises without going through an administrator.  Also allows user settings to be changed so that:
- users can't add anything
- users can submit new exercises and ingredients for approval (current behavior)
- users can submit new exercises and ingredients without needing approval

fixes #382 