### PR TITLE
apache fqn fix

### DIFF
--- a/extras/docker/apache/Dockerfile
+++ b/extras/docker/apache/Dockerfile
@@ -21,7 +21,10 @@ ENV LC_ALL en_US.UTF-8
 
 
 # Install dependencies
-RUN apt-get install -y apache2 libapache2-mod-wsgi-py3
+RUN apt-get update && \
+    apt-get install -y \
+        apache2 \
+        libapache2-mod-wsgi-py3
 
 # Configure apache
 RUN a2dissite 000-default.conf
@@ -59,6 +62,9 @@ RUN chmod o+w -R ~/db/ \
     && python manage.py collectstatic --noinput
 
 USER root
+
+RUN echo "ServerName localhost" | sudo tee /etc/apache2/conf-available/fqdn.conf && \
+    sudo a2enconf fqdn
 
 ENTRYPOINT ["/usr/sbin/apache2ctl"]
 CMD ["-D", "FOREGROUND"]


### PR DESCRIPTION
I had some issues to run the docker image wger/apache

I added an apt-update to fix apache2 package dependences and added a commando do register localhost as fqn on apache. 

There's an error building the image : 

django-recaptcha 2.0.2 has requirement django<2.3,>1.11, but you'll have django 1.10.8 which is incompatible.

We have a problem because in order to build the image we need to get the requirements txt fixed to the image download the code and build the image properly. 
