### PR TITLE
Added directive to pass api auth token to wsgi

### DIFF
--- a/extras/docker/apache/wger.conf
+++ b/extras/docker/apache/wger.conf
@@ -9,6 +9,7 @@
     WSGIDaemonProcess wger python-path=/home/wger/src python-home=/home/wger/venv
     WSGIProcessGroup wger
     WSGIScriptAlias / /home/wger/src/wger/wsgi.py
+    WSGIPassAuthorization On
 
     Alias /static/ /home/wger/static/
     <Directory /home/wger/static>


### PR DESCRIPTION
Apache will not pass the authorization token to the application which is needed to access private api endpoint.