### PR TITLE
Support latest dev release (local/remote) with entrypoint

### DIFF
--- a/extras/docker/compose/docker-compose.yml
+++ b/extras/docker/compose/docker-compose.yml
@@ -2,11 +2,10 @@ version: '3.7'
 
 services:
   web:
-    image: wger/devel:2.0-dev
+    image: wger/devel:latest
+    command: bash -c "/home/wger/entrypoint.sh"
     volumes:
-      - type: bind
-        source: ../../../
-        target: /home/wger/src/
+      - 'wger:/home/wger/src'
     ports:
       - 8000:8000
     env_file:
@@ -34,3 +33,4 @@ services:
 
 volumes:
   wger-postgres-data:
+  wger:


### PR DESCRIPTION
### Proposed Changes

  - Allows for docker-compose deployment of latest development dockerfile.
  - Docker volumes now persist as named volumes
  - Entrypoint script is being called directly since 2.0 tag doesn't work

### Please check that the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] New python code has been linted with with flake8 (``flake8 --config .github/linters/.flake8``)
and isort (``isort``) 
- [ ] Added yourself to AUTHORS.rst

### Other questions

* Does this PR introduce a breaking change such as a database migration? (i.e.
what changes might users need to make in their running application due to
this PR?) No just allows for docker-compose deployment of latest development dockerfile.
