### PR TITLE
Convert /core to fstrings

### DIFF
--- a/wger/core/forms.py
+++ b/wger/core/forms.py
@@ -112,7 +112,7 @@ class UserPreferencesForm(forms.ModelForm):
                                'workout_reminder',
                                'workout_duration',
                                ),
-                AccordionGroup("{} ({})".format(_("Gym mode"), _("mobile version only")),
+                AccordionGroup(f"{_('Gym mode')} ({_('mobile version only')})",
                                "timer_active",
                                "timer_pause"
                                ),

--- a/wger/core/management/commands/clear-cache.py
+++ b/wger/core/management/commands/clear-cache.py
@@ -80,24 +80,24 @@ class Command(BaseCommand):
 
             for user in User.objects.all():
                 if int(options['verbosity']) >= 2:
-                    self.stdout.write("* Processing user {0}".format(user.username))
+                    self.stdout.write(f"* Processing user {user.username}")
 
                 for entry in WorkoutLog.objects.filter(user=user).dates('date', 'year'):
 
                     if int(options['verbosity']) >= 3:
-                        self.stdout.write("  Year {0}".format(entry.year))
+                        self.stdout.write(f"  Year {entry.year}")
                     for month in WorkoutLog.objects.filter(user=user,
                                                            date__year=entry.year).dates('date',
                                                                                         'month'):
                         if int(options['verbosity']) >= 3:
-                            self.stdout.write("    Month {0}".format(entry.month))
+                            self.stdout.write(f"    Month {entry.month}")
                         reset_workout_log(user.id, entry.year, entry.month)
                         for day in WorkoutLog.objects.filter(user=user,
                                                              date__year=entry.year,
                                                              date__month=month.month).dates('date',
                                                                                             'day'):
                             if int(options['verbosity']) >= 3:
-                                self.stdout.write("      Day {0}".format(day.day))
+                                self.stdout.write(f"      Day {day.day}")
                             reset_workout_log(user.id, entry.year, entry.month, day)
 
             for language in Language.objects.all():

--- a/wger/core/management/commands/delete-temp-users.py
+++ b/wger/core/management/commands/delete-temp-users.py
@@ -43,4 +43,4 @@ class Command(BaseCommand):
                 counter += 1
                 profile.user.delete()
 
-        self.stdout.write("Deleted {0} temporary users".format(counter))
+        self.stdout.write(f"Deleted {counter} temporary users")

--- a/wger/core/management/commands/extract-i18n.py
+++ b/wger/core/management/commands/extract-i18n.py
@@ -44,5 +44,5 @@ class Command(BaseCommand):
 
         # Print the result
         for i in out:
-            self.stdout.write('msgid "{0}"\n'
-                              'msgstr ""\n\n'.format(i))
+            self.stdout.write(f'msgid "{i}"\n'
+                              'msgstr ""\n\n')

--- a/wger/core/models.py
+++ b/wger/core/models.py
@@ -63,7 +63,7 @@ class Language(models.Model):
         """
         Return a more human-readable representation
         """
-        return "{0} ({1})".format(self.full_name, self.short_name)
+        return f"{self.full_name} ({self.short_name})"
 
     def get_absolute_url(self):
         """
@@ -382,7 +382,7 @@ by the US Department of Agriculture. It is extremely complete, with around
         """
         Return a more human-readable representation
         """
-        return "Profile for user {0}".format(self.user)
+        return f"Profile for user {self.user}"
 
     @property
     def use_metric(self):
@@ -521,7 +521,7 @@ class UserCache(models.Model):
         """
         Return a more human-readable representation
         """
-        return "Cache for user {0}".format(self.user)
+        return f"Cache for user {self.user}"
 
 
 class DaysOfWeek(models.Model):
@@ -582,7 +582,7 @@ class License(models.Model):
         """
         Return a more human-readable representation
         """
-        return "{0} ({1})".format(self.full_name, self.short_name)
+        return f"{self.full_name} ({self.short_name})"
 
     #
     # Own methods

--- a/wger/core/templatetags/wger_extras.py
+++ b/wger/core/templatetags/wger_extras.py
@@ -131,9 +131,9 @@ def render_muscles(muscles=None, muscles_sec=None):
     except IndexError:
         front_back = "front" if out_sec[0].is_front else "back"
 
-    backgrounds = ["images/muscles/main/muscle-{}.svg".format(i.id) for i in out_main] \
-        + ["images/muscles/secondary/muscle-{}.svg".format(i.id) for i in out_sec] \
-        + ["images/muscles/muscular_system_{}.svg".format(front_back)]
+    backgrounds = [f"images/muscles/main/muscle-{i.id}.svg" for i in out_main] \
+        + [f"images/muscles/secondary/muscle-{i.id}.svg" for i in out_sec] \
+        + [f"images/muscles/muscular_system_{front_back}.svg"]
 
     return {"backgrounds": backgrounds,
             "empty": False}
@@ -146,7 +146,7 @@ def language_select(context, language):
     """
 
     return {'language_name': language[1],
-            'path': 'images/icons/flag-{0}.svg'.format(language[0]),
+            'path': f'images/icons/flag-{language[0]}.svg',
             'i18n_path': context['i18n_path'][language[0]]}
 
 
@@ -187,7 +187,7 @@ def fa_class(class_name='', icon_type='fas', fixed_width=True):
     if not class_name:
         return css
 
-    css += '{} fa-{}'.format(icon_type, class_name)
+    css += f'{icon_type} fa-{class_name}'
 
     if fixed_width:
         css += ' fa-fw'

--- a/wger/core/tests/api_base_test.py
+++ b/wger/core/tests/api_base_test.py
@@ -79,14 +79,14 @@ class ApiBaseTestCase(APITestCase):
         """
         Return the URL to use for testing
         """
-        return '/api/{0}/{1}/'.format(self.api_version, self.get_resource_name())
+        return f'/api/{self.api_version}/{self.get_resource_name()}/'
 
     @property
     def url_detail(self):
         """
         Return the detail URL to use for testing
         """
-        return '{0}{1}/'.format(self.url, self.pk)
+        return f'{self.url}{self.pk}/'
 
     def get_credentials(self, username=None):
         """
@@ -399,7 +399,7 @@ class ApiPutTestCase(object):
             #
             # Currently resources that have a 'user' field 'succeed'
             if response.status_code == status.HTTP_201_CREATED:
-                # print('201: {0}'.format(self.url_detail))
+                # print(f'201: {self.url_detail}')
                 obj = self.resource.objects.get(pk=response.data['id'])
                 obj2 = self.resource.objects.get(pk=self.pk)
                 self.assertNotEqual(obj.get_owner_object().user.username,
@@ -408,7 +408,7 @@ class ApiPutTestCase(object):
                 self.assertEqual(count_before + 1, count_after)
 
             elif response.status_code == status.HTTP_403_FORBIDDEN:
-                # print('403: {0}'.format(self.url_detail))
+                # print(f'403: {self.url_detail}')
                 self.assertEqual(count_before, count_after)
         else:
             # Anonymous user

--- a/wger/core/tests/base_testcase.py
+++ b/wger/core/tests/base_testcase.py
@@ -75,13 +75,13 @@ def delete_testcase_add_methods(cls):
         def test_unauthorized(self):
             self.user_login(user)
             self.delete_object(fail=False)
-        setattr(cls, 'test_unauthorized_{0}'.format(user), test_unauthorized)
+        setattr(cls, f'test_unauthorized_{user}', test_unauthorized)
 
     for user in get_user_list(cls.user_success):
         def test_authorized(self):
             self.user_login(user)
             self.delete_object(fail=False)
-        setattr(cls, 'test_authorized_{0}'.format(user), test_authorized)
+        setattr(cls, f'test_authorized_{user}', test_authorized)
 
 
 class BaseTestCase(object):
@@ -172,7 +172,7 @@ class WgerTestCase(BaseTestCase, TestCase):
         """
         Login the user, by default as 'admin'
         """
-        password = '{0}{0}'.format(user)
+        password = f'{user}{user}'
         self.client.login(username=user, password=password)
         self.current_user = user
         self.current_password = password

--- a/wger/core/tests/test_daysofweek.py
+++ b/wger/core/tests/test_daysofweek.py
@@ -28,7 +28,7 @@ class DaysOfWeekRepresentationTestCase(WgerTestCase):
         """
         Test that the representation of an object is correct
         """
-        self.assertEqual("{0}".format(DaysOfWeek.objects.get(pk=1)), 'Monday')
+        self.assertEqual(f"{DaysOfWeek.objects.get(pk=1)}", 'Monday')
 
 
 class DaysOfWeekApiTestCase(api_base_test.ApiBaseResourceTestCase):

--- a/wger/core/tests/test_delete_user.py
+++ b/wger/core/tests/test_delete_user.py
@@ -84,10 +84,10 @@ class DeleteUserByAdminTestCase(WgerTestCase):
         self.assertEqual(User.objects.filter(username='test').count(), 1)
         if fail:
             self.assertIn(response.status_code, (302, 403),
-                          'Unexpected status code for user {0}'.format(self.current_user))
+                          f'Unexpected status code for user {self.current_user}')
         else:
             self.assertEqual(response.status_code, 200,
-                             'Unexpected status code for user {0}'.format(self.current_user))
+                             f'Unexpected status code for user {self.current_user}')
 
         # Wrong admin password
         if not fail:

--- a/wger/core/tests/test_language.py
+++ b/wger/core/tests/test_language.py
@@ -39,7 +39,7 @@ class LanguageRepresentationTestCase(WgerTestCase):
         """
         Test that the representation of an object is correct
         """
-        self.assertEqual("{0}".format(Language.objects.get(pk=1)), 'Deutsch (de)')
+        self.assertEqual(f"{Language.objects.get(pk=1)}", 'Deutsch (de)')
 
 
 class LanguageOverviewTest(WgerAccessTestCase):

--- a/wger/core/tests/test_license.py
+++ b/wger/core/tests/test_license.py
@@ -34,7 +34,7 @@ class LicenseRepresentationTestCase(WgerTestCase):
         """
         Test that the representation of an object is correct
         """
-        self.assertEqual("{0}".format(License.objects.get(pk=1)),
+        self.assertEqual(f"{License.objects.get(pk=1)}",
                          'A cool and free license - Germany (ACAFL - DE)')
 
 

--- a/wger/core/tests/test_repetition_unit.py
+++ b/wger/core/tests/test_repetition_unit.py
@@ -34,7 +34,7 @@ class RepresentationTestCase(WgerTestCase):
         """
         Test that the representation of an object is correct
         """
-        self.assertEqual("{0}".format(RepetitionUnit.objects.get(pk=1)), 'Repetitions')
+        self.assertEqual(f"{RepetitionUnit.objects.get(pk=1)}", 'Repetitions')
 
 
 class OverviewTest(WgerAccessTestCase):

--- a/wger/core/tests/test_robots_txt.py
+++ b/wger/core/tests/test_robots_txt.py
@@ -29,5 +29,5 @@ class RobotsTxtTestCase(WgerTestCase):
 
         response = self.client.get(reverse('robots'))
         for lang in Language.objects.all():
-            self.assertTrue('wger.de/{0}/sitemap.xml'.format(lang.short_name)
+            self.assertTrue(f'wger.de/{lang.short_name}/sitemap.xml'
                             in str(response.content))

--- a/wger/core/tests/test_weight_unit.py
+++ b/wger/core/tests/test_weight_unit.py
@@ -34,7 +34,7 @@ class RepresentationTestCase(WgerTestCase):
         """
         Test that the representation of an object is correct
         """
-        self.assertEqual("{0}".format(WeightUnit.objects.get(pk=1)), 'kg')
+        self.assertEqual(f"{WeightUnit.objects.get(pk=1)}", 'kg')
 
 
 class OverviewTest(WgerAccessTestCase):


### PR DESCRIPTION
Addressing #508 ; converted all instances of string format method to fstrings in the /core app. Can't change the strings that are inside _() ugettext functions though, since it would interfere with the translation.