### PR TITLE
#560 bugfix (WorkoutSessionSerializer for api)

### DIFF
--- a/wger/manager/api/serializers.py
+++ b/wger/manager/api/serializers.py
@@ -54,9 +54,13 @@ class WorkoutSessionSerializer(serializers.ModelSerializer):
     """
     Workout session serializer
     """
+    user = serializers.PrimaryKeyRelatedField(
+        read_only=True, default=serializers.CurrentUserDefault()
+    )
+
     class Meta:
         model = WorkoutSession
-        exclude = ('user',)
+        fields = '__all__'
 
 
 class WorkoutLogSerializer(serializers.ModelSerializer):

--- a/wger/manager/tests/test_workout_session.py
+++ b/wger/manager/tests/test_workout_session.py
@@ -245,7 +245,7 @@ class WorkoutSessionApiTestCase(api_base_test.ApiBaseResourceTestCase):
     resource = WorkoutSession
     private_resource = True
     data = {'workout': 3,
-            'date': datetime.date(2014, 1, 30),
+            'date': datetime.date(2014, 1, 25),
             'notes': 'My new insights',
             'impression': '3',
             'time_start': datetime.time(10, 0),


### PR DESCRIPTION
Correct WorkoutSessionApiTestCase

### Proposed Changes

  - Make user readonly field on WorkoutSessionSerializer
  - Correct WorkoutSessionApiTestCase 
  -

### Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)   existing tests work, no new functions added
- [x] New python code has been linted with with flake8 (``flake8 --config .github/linters/.flake8``)
and isort (``isort``) yeah

