### PR TITLE
Add minimum length to Ingredient name (Issue #426)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -32,6 +32,7 @@ Developers
 * Biplov - https://github.com/beingbiplov
 * Rashmi Kamath - https://github.com/Rkamath2
 * Anthony (Ryo) Wright - https://github.com/ryowright
+* Austin Leung - https://github.com/austin-leung
 
 Translators
 -----------

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -29,8 +29,8 @@ from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.core.validators import (
     MaxValueValidator,
-    MinValueValidator,
-    MinLengthValidator
+    MinLengthValidator,
+    MinValueValidator
 )
 from django.db import models
 from django.template.loader import render_to_string

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -29,7 +29,8 @@ from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.core.validators import (
     MaxValueValidator,
-    MinValueValidator
+    MinValueValidator,
+    MinLengthValidator
 )
 from django.db import models
 from django.template.loader import render_to_string
@@ -289,7 +290,8 @@ class Ingredient(AbstractSubmissionModel, AbstractLicenseModel, models.Model):
                                    editable=False)
 
     name = models.CharField(max_length=200,
-                            verbose_name=_('Name'), )
+                            verbose_name=_('Name'),
+                            validators=[MinLengthValidator(3)])
 
     energy = models.IntegerField(verbose_name=_('Energy'),
                                  help_text=_('In kcal per 100g'))

--- a/wger/nutrition/tests/test_ingredient.py
+++ b/wger/nutrition/tests/test_ingredient.py
@@ -122,6 +122,52 @@ class AddIngredientTestCase(WgerAddTestCase):
             self.assertEqual(ingredient.status, Ingredient.STATUS_PENDING)
 
 
+class IngredientNameShortTestCase(WgerTestCase):
+    """
+    Tests that ingredient cannot have name with length less than 3
+    """
+    data = {'name': 'Ui',
+            'sodium': 2,
+            'energy': 200,
+            'fat': 10,
+            'carbohydrates_sugar': 5,
+            'fat_saturated': 3.14,
+            'fibres': 2.1,
+            'protein': 20,
+            'carbohydrates': 10,
+            'license': 2,
+            'license_author': 'me!'}
+
+    def test_add_ingredient_short_name(self):
+        """
+        Test that ingredient cannot be added with name of length less than 3
+        """
+        self.user_login('admin')
+
+        count_before = Ingredient.objects.count()
+
+        response = self.client.post(reverse('nutrition:ingredient:add'), self.data)
+        count_after = Ingredient.objects.count()
+        self.assertEqual(response.status_code, 200)
+
+        # Ingredient was not added
+        self.assertEqual(count_before, count_after)
+
+    def test_edit_ingredient_short_name(self):
+        """
+        Test that ingredient cannot be edited to name of length less than 3
+        """
+        self.user_login('admin')
+
+        response = self.client.post(reverse('nutrition:ingredient:edit',
+                                    kwargs={'pk': '1'}), self.data)
+        self.assertEqual(response.status_code, 200)
+
+        ingredient = Ingredient.objects.get(pk=1)
+        # Ingredient was not edited
+        self.assertNotEqual(ingredient.update_date, datetime.date.today())
+
+
 class IngredientDetailTestCase(WgerTestCase):
     """
     Tests the ingredient details page


### PR DESCRIPTION
### Proposed Changes

  - Change minimum required length for an ingredient name to be 3 (affects create/edit)

### Please check that the PR fulfills these requirements

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] New python code has been linted with with flake8 (``flake8 --config .github/linters/.flake8``)
and isort (``isort``) 
- [X] Added yourself to AUTHORS.rst

### Other questions

* Does this PR introduce a breaking change such as a database migration? (i.e.
what changes might users need to make in their running application due to
this PR?)
No

This is what it looks like now if you try to create/edit an ingredient name of too few characters:
![image](https://user-images.githubusercontent.com/34123199/101267796-f8f6a580-372a-11eb-925f-93588d7bb58d.png)

One thing I'm not sure about is whether I should write tests for this. I see tests around the Ingredient model in `wger/nutrition/tests/test_ingredient.py`, but I don't think we currently test other validators such as `MinValueValidator`