### PR TITLE
Return muscle image URLs from model (fixes #547)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -38,6 +38,7 @@ Developers
 * Hita Kambhamettu - https://github.com/Hita-K 
 * Derek Li - https://github.com/derekli17
 * Noah Pinter - https://github.com/nopinter
+* Kevin Geng - https://github.com/gengkev
 
 Translators
 -----------

--- a/wger/core/templates/tags/muscles.html
+++ b/wger/core/templates/tags/muscles.html
@@ -1,6 +1,6 @@
 {% load static %}
 {% if not empty %}
 <div class="muscle-background mx-auto"
-     style="background-image: {% for background in backgrounds %}url({% static background %}){% if not forloop.last %},{% endif %}{% endfor %};">
+     style="background-image: {% for background in backgrounds %}url({{ background }}){% if not forloop.last %},{% endif %}{% endfor %};">
 </div>
 {% endif %}

--- a/wger/core/templatetags/wger_extras.py
+++ b/wger/core/templatetags/wger_extras.py
@@ -18,6 +18,7 @@
 from django import template
 from django.conf import settings
 from django.db.models import QuerySet
+from django.templatetags.static import static
 from django.utils.html import strip_spaces_between_tags
 from django.utils.safestring import mark_safe
 from django.utils.translation import (
@@ -131,9 +132,9 @@ def render_muscles(muscles=None, muscles_sec=None):
     except IndexError:
         front_back = "front" if out_sec[0].is_front else "back"
 
-    backgrounds = [f"images/muscles/main/muscle-{i.id}.svg" for i in out_main] \
-        + [f"images/muscles/secondary/muscle-{i.id}.svg" for i in out_sec] \
-        + [f"images/muscles/muscular_system_{front_back}.svg"]
+    backgrounds = [i.image_url_main for i in out_main] \
+        + [i.image_url_secondary for i in out_sec] \
+        + [static(f"images/muscles/muscular_system_{front_back}.svg")]
 
     return {"backgrounds": backgrounds,
             "empty": False}

--- a/wger/exercises/api/serializers.py
+++ b/wger/exercises/api/serializers.py
@@ -107,4 +107,4 @@ class MuscleSerializer(serializers.ModelSerializer):
     """
     class Meta:
         model = Muscle
-        fields = '__all__'
+        fields = ['name', 'is_front', 'image_url_main', 'image_url_secondary']

--- a/wger/exercises/models.py
+++ b/wger/exercises/models.py
@@ -27,6 +27,7 @@ from django.core import mail
 from django.core.validators import MinLengthValidator
 from django.db import models
 from django.template.loader import render_to_string
+from django.templatetags.static import static
 from django.urls import reverse
 from django.utils import translation
 from django.utils.text import slugify
@@ -67,6 +68,16 @@ class Muscle(models.Model):
     # Metaclass to set some other properties
     class Meta:
         ordering = ["name", ]
+
+    # Image to use when displaying this as a main muscle in an exercise
+    @property
+    def image_url_main(self):
+        return static(f"images/muscles/main/muscle-{self.id}.svg")
+
+    # Image to use when displaying this as a secondary muscle in an exercise
+    @property
+    def image_url_secondary(self):
+        return static(f"images/muscles/secondary/muscle-{self.id}.svg")
 
     def __str__(self):
         """

--- a/wger/exercises/tests/test_muscles.py
+++ b/wger/exercises/tests/test_muscles.py
@@ -41,6 +41,12 @@ class MuscleRepresentationTestCase(WgerTestCase):
         """
         self.assertEqual("{0}".format(Muscle.objects.get(pk=1)), 'Anterior testoid')
 
+        # Check image URL properties
+        self.assertIn("images/muscles/main/muscle-2.svg",
+                      Muscle.objects.get(pk=2).image_url_main)
+        self.assertIn("images/muscles/secondary/muscle-1.svg",
+                      Muscle.objects.get(pk=1).image_url_secondary)
+
 
 class MuscleAdminOverviewTest(WgerAccessTestCase):
     """
@@ -148,3 +154,14 @@ class MuscleApiTestCase(api_base_test.ApiBaseResourceTestCase):
     private_resource = False
     data = {'name': 'The name',
             'is_front': True}
+
+    def test_get_detail(self):
+        super().test_get_detail()
+
+        # Check that image URLs are present in response
+        response = self.client.get(self.url_detail)
+        response_object = response.json()
+        self.assertIn("images/muscles/main/muscle-1.svg",
+                      response_object["image_url_main"])
+        self.assertIn("images/muscles/secondary/muscle-1.svg",
+                      response_object["image_url_secondary"])


### PR DESCRIPTION
### Proposed Changes

Each muscle is associated with a primary and secondary image, which are used if it is the primary or secondary muscle in an exercise, respectively. The previous code computed the URLs of these images in the `render_muscle()` function. This commit generalizes this slightly by moving that calculation to the muscle model instead.

Question: Does this address the intent of the original issue #547, or should additional refactoring be made? For instance, we could use an `ImageField`, similar to `ExerciseImage`, so that muscle images can be uploaded and edited by the admin (rather than only using the fixtures).

### Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] New python code has been linted with with flake8 (``flake8 --config .github/linters/.flake8``)
and isort (``isort``) 
- [x] Added yourself to AUTHORS.rst

### Other questions

* Does this PR introduce a breaking change such as a database migration? (i.e. what changes might users need to make in their running application due to this PR?)
  No
