### PR TITLE
Don't assume gender when assuming user

### DIFF
--- a/wger/core/templates/base.html
+++ b/wger/core/templates/base.html
@@ -10,7 +10,7 @@
 {% if trainer_identity %}
 <div class="alert alert-info" style="margin-top: 1em;">
     {% blocktrans with current_user=user|format_username %}You are
-browsing the site as the user "{{current_user}}", all actions are performed on his data.
+    browsing the site as the user "{{current_user}}", all actions are performed on their data.
     {% endblocktrans %}
     <a href="{% url 'core:user:trainer-login' trainer_identity %}" class="alert-link">
         {% blocktrans with target=user.userprofile.gym.name %}Back to "{{ target }}"{% endblocktrans %}

--- a/wger/core/templates/base_wide.html
+++ b/wger/core/templates/base_wide.html
@@ -8,7 +8,7 @@
 {% if trainer_identity %}
 <div class="alert alert-info" style="margin-top: 1em;">
     {% blocktrans with current_user=user|format_username %}You are
-browsing the site as the user "{{current_user}}", all actions are performed on his data.
+    browsing the site as the user "{{current_user}}", all actions are performed on their data.
     {% endblocktrans %}
     <a href="{% url 'core:user:trainer-login' trainer_identity %}" class="alert-link">
         {% blocktrans with target=user.userprofile.gym.name %}Back to "{{ target }}"{% endblocktrans %}

--- a/wger/locale/bg/LC_MESSAGES/django.po
+++ b/wger/locale/bg/LC_MESSAGES/django.po
@@ -569,7 +569,7 @@ msgstr "Нещо се случи, което причини грешка."
 #, python-format
 msgid ""
 "You are\n"
-"browsing the site as the user \"%(current_user)s\", all actions are performed on his data.\n"
+"browsing the site as the user \"%(current_user)s\", all actions are performed on their data.\n"
 "    "
 msgstr ""
 

--- a/wger/locale/cs/LC_MESSAGES/django.po
+++ b/wger/locale/cs/LC_MESSAGES/django.po
@@ -569,7 +569,7 @@ msgstr "Nastalo něco, co způsobilo chybu."
 #, python-format
 msgid ""
 "You are\n"
-"browsing the site as the user \"%(current_user)s\", all actions are performed on his data.\n"
+"browsing the site as the user \"%(current_user)s\", all actions are performed on their data.\n"
 "    "
 msgstr "Procházíte\nweb, jako uživatel \"%(current_user)s\", všechny akce budou zapsány do jeho údajů.\n    "
 

--- a/wger/locale/da/LC_MESSAGES/django.po
+++ b/wger/locale/da/LC_MESSAGES/django.po
@@ -567,7 +567,7 @@ msgstr ""
 #, python-format
 msgid ""
 "You are\n"
-"browsing the site as the user \"%(current_user)s\", all actions are performed on his data.\n"
+"browsing the site as the user \"%(current_user)s\", all actions are performed on their data.\n"
 "    "
 msgstr ""
 

--- a/wger/locale/de/LC_MESSAGES/django.po
+++ b/wger/locale/de/LC_MESSAGES/django.po
@@ -568,7 +568,7 @@ msgstr "Etwas hat einen Fehler verursacht."
 #, python-format
 msgid ""
 "You are\n"
-"browsing the site as the user \"%(current_user)s\", all actions are performed on his data.\n"
+"browsing the site as the user \"%(current_user)s\", all actions are performed on their data.\n"
 "    "
 msgstr "Sie sind benutzen die Anwengung als der Benutzer \"%(current_user)s\", alle Aktionen werden auf seine Daten ausgeführt."
 

--- a/wger/locale/el/LC_MESSAGES/django.po
+++ b/wger/locale/el/LC_MESSAGES/django.po
@@ -568,7 +568,7 @@ msgstr "Κάτι συνέβει που προκάλεσε ένα σφάλμα."
 #, python-format
 msgid ""
 "You are\n"
-"browsing the site as the user \"%(current_user)s\", all actions are performed on his data.\n"
+"browsing the site as the user \"%(current_user)s\", all actions are performed on their data.\n"
 "    "
 msgstr "Περιηγήστε στην σελίδα ώς χρήστης \"%(current_user)s\", όλες οι ενέργειες θα έχουν ως αποτέλεσμα να επηρεάσουν αυτόν τον χρήστη."
 

--- a/wger/locale/en/LC_MESSAGES/django.po
+++ b/wger/locale/en/LC_MESSAGES/django.po
@@ -559,7 +559,7 @@ msgstr ""
 msgid ""
 "You are\n"
 "browsing the site as the user \"%(current_user)s\", all actions are "
-"performed on his data.\n"
+"performed on their data.\n"
 "    "
 msgstr ""
 

--- a/wger/locale/es/LC_MESSAGES/django.po
+++ b/wger/locale/es/LC_MESSAGES/django.po
@@ -572,7 +572,7 @@ msgstr "Algo ha sucedido que ha causadi un error."
 #, python-format
 msgid ""
 "You are\n"
-"browsing the site as the user \"%(current_user)s\", all actions are performed on his data.\n"
+"browsing the site as the user \"%(current_user)s\", all actions are performed on their data.\n"
 "    "
 msgstr "Estás usando la aplicación como el usuario \"%(current_user)s\", todas las acciones que se realizan con sus datos.\n    "
 

--- a/wger/locale/fa/LC_MESSAGES/django.po
+++ b/wger/locale/fa/LC_MESSAGES/django.po
@@ -566,7 +566,7 @@ msgstr "اتفاقی موجب خطا شده است"
 #, python-format
 msgid ""
 "You are\n"
-"browsing the site as the user \"%(current_user)s\", all actions are performed on his data.\n"
+"browsing the site as the user \"%(current_user)s\", all actions are performed on their data.\n"
 "    "
 msgstr "شما به عنوان کاربر %(current_user)s در حال جستجو در سایت هستید.\nجستجو شما قابل مشاهده است."
 

--- a/wger/locale/fi/LC_MESSAGES/django.po
+++ b/wger/locale/fi/LC_MESSAGES/django.po
@@ -567,7 +567,7 @@ msgstr ""
 #, python-format
 msgid ""
 "You are\n"
-"browsing the site as the user \"%(current_user)s\", all actions are performed on his data.\n"
+"browsing the site as the user \"%(current_user)s\", all actions are performed on their data.\n"
 "    "
 msgstr ""
 

--- a/wger/locale/fr/LC_MESSAGES/django.po
+++ b/wger/locale/fr/LC_MESSAGES/django.po
@@ -577,7 +577,7 @@ msgstr "Quelque-chose s'est passé et a causé un erreur."
 #, python-format
 msgid ""
 "You are\n"
-"browsing the site as the user \"%(current_user)s\", all actions are performed on his data.\n"
+"browsing the site as the user \"%(current_user)s\", all actions are performed on their data.\n"
 "    "
 msgstr "Vous êtes\nconnectés en tant que \"%(current_user)s\", toutes les actions seront faîtes sur ses\ndonnées."
 

--- a/wger/locale/hu/LC_MESSAGES/django.po
+++ b/wger/locale/hu/LC_MESSAGES/django.po
@@ -567,7 +567,7 @@ msgstr "Valami történt ami hibát okozott."
 #, python-format
 msgid ""
 "You are\n"
-"browsing the site as the user \"%(current_user)s\", all actions are performed on his data.\n"
+"browsing the site as the user \"%(current_user)s\", all actions are performed on their data.\n"
 "    "
 msgstr ""
 

--- a/wger/locale/it/LC_MESSAGES/django.po
+++ b/wger/locale/it/LC_MESSAGES/django.po
@@ -572,7 +572,7 @@ msgstr "È successo qualcosa che ha causato un errore."
 #, python-format
 msgid ""
 "You are\n"
-"browsing the site as the user \"%(current_user)s\", all actions are performed on his data.\n"
+"browsing the site as the user \"%(current_user)s\", all actions are performed on their data.\n"
 "    "
 msgstr "Stai\nnavigando nel sito come utente \"%(current_user)s\", tutte le azioni vengono eseguite sui suoi dati."
 

--- a/wger/locale/ja/LC_MESSAGES/django.po
+++ b/wger/locale/ja/LC_MESSAGES/django.po
@@ -569,7 +569,7 @@ msgstr ""
 #, python-format
 msgid ""
 "You are\n"
-"browsing the site as the user \"%(current_user)s\", all actions are performed on his data.\n"
+"browsing the site as the user \"%(current_user)s\", all actions are performed on their data.\n"
 "    "
 msgstr ""
 

--- a/wger/locale/nl/LC_MESSAGES/django.po
+++ b/wger/locale/nl/LC_MESSAGES/django.po
@@ -572,7 +572,7 @@ msgstr "Er is iets gebeurd dat een fout veroorzaakte."
 #, python-format
 msgid ""
 "You are\n"
-"browsing the site as the user \"%(current_user)s\", all actions are performed on his data.\n"
+"browsing the site as the user \"%(current_user)s\", all actions are performed on their data.\n"
 "    "
 msgstr "Je bladert door de site als gebruiker \"%(current_user)s\", alle acties worden uitgevoerd op diens data."
 

--- a/wger/locale/no/LC_MESSAGES/django.po
+++ b/wger/locale/no/LC_MESSAGES/django.po
@@ -568,7 +568,7 @@ msgstr "Noe skjedde som forårsaket en feil."
 #, python-format
 msgid ""
 "You are\n"
-"browsing the site as the user \"%(current_user)s\", all actions are performed on his data.\n"
+"browsing the site as the user \"%(current_user)s\", all actions are performed on their data.\n"
 "    "
 msgstr "Du surfer på denne siden som brukeren: \"%(current_user)s\", alle handlinger blir utført på denne brukerens data."
 

--- a/wger/locale/os/LC_MESSAGES/django.po
+++ b/wger/locale/os/LC_MESSAGES/django.po
@@ -566,7 +566,7 @@ msgstr ""
 #, python-format
 msgid ""
 "You are\n"
-"browsing the site as the user \"%(current_user)s\", all actions are performed on his data.\n"
+"browsing the site as the user \"%(current_user)s\", all actions are performed on their data.\n"
 "    "
 msgstr ""
 

--- a/wger/locale/pl/LC_MESSAGES/django.po
+++ b/wger/locale/pl/LC_MESSAGES/django.po
@@ -571,7 +571,7 @@ msgstr "Dokonał się błąd."
 #, python-format
 msgid ""
 "You are\n"
-"browsing the site as the user \"%(current_user)s\", all actions are performed on his data.\n"
+"browsing the site as the user \"%(current_user)s\", all actions are performed on their data.\n"
 "    "
 msgstr "Przeglądasz stronę jako  \"%(current_user)s\", wszystkie akcje operują na jego danych."
 

--- a/wger/locale/pt_BR/LC_MESSAGES/django.po
+++ b/wger/locale/pt_BR/LC_MESSAGES/django.po
@@ -572,7 +572,7 @@ msgstr "Algo aconteceu que causou um erro."
 #, python-format
 msgid ""
 "You are\n"
-"browsing the site as the user \"%(current_user)s\", all actions are performed on his data.\n"
+"browsing the site as the user \"%(current_user)s\", all actions are performed on their data.\n"
 "    "
 msgstr "Você está\nnavegando no site como \"%(current_user)s\", todas as ações são executadas nos seus dados."
 

--- a/wger/locale/ro/LC_MESSAGES/django.po
+++ b/wger/locale/ro/LC_MESSAGES/django.po
@@ -568,7 +568,7 @@ msgstr ""
 #, python-format
 msgid ""
 "You are\n"
-"browsing the site as the user \"%(current_user)s\", all actions are performed on his data.\n"
+"browsing the site as the user \"%(current_user)s\", all actions are performed on their data.\n"
 "    "
 msgstr ""
 

--- a/wger/locale/ru/LC_MESSAGES/django.po
+++ b/wger/locale/ru/LC_MESSAGES/django.po
@@ -572,7 +572,7 @@ msgstr "Произошли действия, которые вызвали ош�
 #, python-format
 msgid ""
 "You are\n"
-"browsing the site as the user \"%(current_user)s\", all actions are performed on his data.\n"
+"browsing the site as the user \"%(current_user)s\", all actions are performed on their data.\n"
 "    "
 msgstr "Вы просматриваете сайт как пользователь \"%(current_user)s\", все действия выполняются на его данных."
 

--- a/wger/locale/sv/LC_MESSAGES/django.po
+++ b/wger/locale/sv/LC_MESSAGES/django.po
@@ -569,7 +569,7 @@ msgstr "Hände något som orsakat ett fel."
 #, python-format
 msgid ""
 "You are\n"
-"browsing the site as the user \"%(current_user)s\", all actions are performed on his data.\n"
+"browsing the site as the user \"%(current_user)s\", all actions are performed on their data.\n"
 "    "
 msgstr "Du besöker denna sida som användare \"%(current_user)s\", alla handlingar påverkar dennes data."
 

--- a/wger/locale/tr/LC_MESSAGES/django.po
+++ b/wger/locale/tr/LC_MESSAGES/django.po
@@ -567,7 +567,7 @@ msgstr ""
 #, python-format
 msgid ""
 "You are\n"
-"browsing the site as the user \"%(current_user)s\", all actions are performed on his data.\n"
+"browsing the site as the user \"%(current_user)s\", all actions are performed on their data.\n"
 "    "
 msgstr ""
 

--- a/wger/locale/uk/LC_MESSAGES/django.po
+++ b/wger/locale/uk/LC_MESSAGES/django.po
@@ -570,7 +570,7 @@ msgstr "Сталося щось, що призвело до помилки."
 #, python-format
 msgid ""
 "You are\n"
-"browsing the site as the user \"%(current_user)s\", all actions are performed on his data.\n"
+"browsing the site as the user \"%(current_user)s\", all actions are performed on their data.\n"
 "    "
 msgstr "Ви переглядаєте сайт як користувач \"%(current_user)s\", всі дії виконуються з його даними"
 

--- a/wger/locale/zh-Hans/LC_MESSAGES/django.po
+++ b/wger/locale/zh-Hans/LC_MESSAGES/django.po
@@ -567,7 +567,7 @@ msgstr "引起错误的事情发生"
 #, python-format
 msgid ""
 "You are\n"
-"browsing the site as the user \"%(current_user)s\", all actions are performed on his data.\n"
+"browsing the site as the user \"%(current_user)s\", all actions are performed on their data.\n"
 "    "
 msgstr ""
 

--- a/wger/locale/zh_CN/LC_MESSAGES/django.po
+++ b/wger/locale/zh_CN/LC_MESSAGES/django.po
@@ -571,7 +571,7 @@ msgstr "某个问题导致了错误."
 #, python-format
 msgid ""
 "You are\n"
-"browsing the site as the user \"%(current_user)s\", all actions are performed on his data.\n"
+"browsing the site as the user \"%(current_user)s\", all actions are performed on their data.\n"
 "    "
 msgstr "你正在以用户\"%(current_user)s\"浏览这个站点.\n任何操作都会执行在他的数据上."
 

--- a/wger/locale/zh_TW/LC_MESSAGES/django.po
+++ b/wger/locale/zh_TW/LC_MESSAGES/django.po
@@ -566,7 +566,7 @@ msgstr ""
 #, python-format
 msgid ""
 "You are\n"
-"browsing the site as the user \"%(current_user)s\", all actions are performed on his data.\n"
+"browsing the site as the user \"%(current_user)s\", all actions are performed on their data.\n"
 "    "
 msgstr ""
 


### PR DESCRIPTION
### Proposed Changes
Replace the message on `/user/<id>/trainer-login` to be inclusive of all genders

### Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] New python code has been linted with with flake8 (``flake8 --config .github/linters/.flake8``)
and isort (``isort``) 
- [x] Added yourself to AUTHORS.rst

### Other questions
I couldn't figure out how to compile the translations or if this was needed locally vs in production. Please let me know how to do this if it changes the files changed in the PR!
