### PR TITLE
Show nutritional values per meal

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -49,6 +49,8 @@ Developers
 * Kevin Geng - https://github.com/gengkev
 * Karmen Lu - https://github.com/klu17
 * Aaron Kimbrell - https://github.com/aronwk-aaron
+* Aaron Bassett - https://github.com/aaronbassett
+* Rachael Wright-Munn - https://github.com/ChaelCodes
 
 
 Translators

--- a/wger/nutrition/templates/plan/view.html
+++ b/wger/nutrition/templates/plan/view.html
@@ -68,7 +68,7 @@ function wgerCustomModalInit()
     </tr>
     {% for meal in plan.meal_set.select_related %}
     <tr>
-        <td {% if meal.mealitem_set.count %}rowspan="{{meal.mealitem_set.count}}"{% endif %}>
+        <td {% if meal.mealitem_set.count %}rowspan="{{meal.mealitem_set.count|add:1}}"{% endif %}>
             <strong>
             {% trans "Nr."%} {{ forloop.counter }}
             {% if meal.time %} &ndash; {{meal.time|time:"H:i"}}{% endif %}
@@ -146,6 +146,14 @@ function wgerCustomModalInit()
             {% endif %}
         {% endfor %}
 
+        <tr>
+            <td></td>
+            <td class="align-right">{{meal.get_nutritional_values.energy|floatformat:1}} /
+                                    {{meal.get_nutritional_values.energy_kilojoule|floatformat:1}}</td>
+            <td class="align-right">{{meal.get_nutritional_values.protein|floatformat:1}}</td>
+            <td class="align-right">{{meal.get_nutritional_values.carbohydrates|floatformat:1}}</td>
+            <td class="align-right">{{meal.get_nutritional_values.fat|floatformat:1}}</td>
+        </tr>
     {% empty %}
     {% if is_owner %}
     <tr>

--- a/wger/nutrition/tests/test_plan.py
+++ b/wger/nutrition/tests/test_plan.py
@@ -162,6 +162,22 @@ class PlanDailyCaloriesTestCase(WgerTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'goal amount of calories')
 
+    def test_meal_overview(self):
+        """
+        Tests the meal overview row
+        """
+
+        # Plan has daily calories goal
+        self.user_login('test')
+        plan = NutritionPlan.objects.get(pk=1)
+        plan.has_goal_calories = True
+        plan.save()
+
+        # Can find goal calories text
+        response = self.client.get(reverse('nutrition:plan:view', kwargs={'id': 1}))
+        meal = response.context['plan'].meal_set.select_related()[0]
+        self.assertTrue(meal.get_nutritional_values()['energy'])
+
 
 class PlanApiTestCase(api_base_test.ApiBaseResourceTestCase):
     """


### PR DESCRIPTION
### Proposed Changes
closes #581
Add row that summarizes meal nutritional values in plan.
![image](https://user-images.githubusercontent.com/8124558/109349014-46bf0d80-7843-11eb-820e-ee572c45a108.png)

### Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] New python code has been linted with with flake8 (``flake8 --config .github/linters/.flake8``)
and isort (``isort``) 
- [x] Added yourself to AUTHORS.rst

### Other questions

* Does this PR introduce a breaking change such as a database migration%3F
No breaking changes - UI only.
