### PR TITLE
Limit how often set rows can be updated to avoid excessive updates to the form

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -51,6 +51,7 @@ Developers
 * Aaron Kimbrell - https://github.com/aronwk-aaron
 * Aaron Bassett - https://github.com/aaronbassett
 * Rachael Wright-Munn - https://github.com/ChaelCodes
+* Will Pearson - https://github.com/qagoose
 
 
 Translators

--- a/wger/core/static/js/wger-core.js
+++ b/wger/core/static/js/wger-core.js
@@ -97,6 +97,17 @@ function wgerSetupSortable() {
   });
 }
 
+/* 
+Functions related to site performance 
+*/
+
+function debounce(func, delay, timer) {
+  // Delays calling a function until it hasn't been called for the set delay
+  clearTimeout(timer);
+  timer = setTimeout(func, delay);
+  return timer;
+}
+
 /*
  Functions related to the user's preferences
  */
@@ -520,9 +531,10 @@ function wgerInitEditSet() {
   initRemoveExerciseFormset();
 
   // Slider to set the number of sets
+  var setsSliderTimer;
   $('#id_sets').on('input', function () {
-    updateAllExerciseFormset();
     $('#id_sets_value').html($('#id_sets').val());
+    setsSliderTimer = debounce(updateAllExerciseFormset, 250, setsSliderTimer);
   });
 
   /*

--- a/wger/core/static/js/wger-core.js
+++ b/wger/core/static/js/wger-core.js
@@ -97,17 +97,6 @@ function wgerSetupSortable() {
   });
 }
 
-/* 
-Functions related to site performance 
-*/
-
-function debounce(func, delay, timer) {
-  // Delays calling a function until it hasn't been called for the set delay
-  clearTimeout(timer);
-  timer = setTimeout(func, delay);
-  return timer;
-}
-
 /*
  Functions related to the user's preferences
  */
@@ -531,10 +520,12 @@ function wgerInitEditSet() {
   initRemoveExerciseFormset();
 
   // Slider to set the number of sets
-  var setsSliderTimer;
   $('#id_sets').on('input', function () {
     $('#id_sets_value').html($('#id_sets').val());
-    setsSliderTimer = debounce(updateAllExerciseFormset, 250, setsSliderTimer);
+  });
+  
+  $('#id_sets').on('pointerup', function () {
+    updateAllExerciseFormset();
   });
 
   /*


### PR DESCRIPTION
### Proposed Changes

  - Debounce the sets slider on the add exercise form to prevent excessive updates to the form (fixes #610 )

### Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] New python code has been linted with with flake8 (``flake8 --config .github/linters/.flake8``)
and isort (``isort``) 
- [x] Added yourself to AUTHORS.rst

No tests added, as this is a JavaScript fix, and I don't believe there are any JS/UI tests.

Checked in recent versions of Chrome, Firefox, and Edge (Chromium) and all behave as expected.