### PR TITLE
fix(): Disable "Log in as this user" when gym doesn't match

### DIFF
--- a/wger/core/templates/user/overview.html
+++ b/wger/core/templates/user/overview.html
@@ -469,6 +469,26 @@
 {#         #}
 {% block options %}
 {% if perms.gym.gym_trainer %}
-    <a href="{% url 'core:user:trainer-login' current_user.pk %}" class="btn btn-success btn-sm">{% trans "Log in as this user" %}</a>
+
+    <style>
+        .btn.btn-sm.btn-secondary {
+            background: #EEE;
+            color: #AAA;
+            cursor: not-allowed;
+        }
+    </style>
+
+    <a
+       {% if enable_login_button %}
+        href="{% url 'core:user:trainer-login' current_user.pk %}"
+        class="btn btn-sm btn-success"
+       {% else %}
+        href="#"
+        title="{% trans 'Admin login is only available for users in' %} &ldquo;{{gym_name}}&rdquo;"
+        class="btn btn-sm btn-secondary"
+       {% endif %}
+    >
+       {% trans "Log in as this user" %}
+    </a>
 {% endif %}
 {% endblock %}

--- a/wger/core/views/user.py
+++ b/wger/core/views/user.py
@@ -520,6 +520,12 @@ class UserDetailView(LoginRequiredMixin, WgerMultiplePermissionRequiredMixin, De
         context['session'] = WorkoutSession.objects.filter(user=self.object).order_by('-date')[:10]
         context['admin_notes'] = AdminUserNote.objects.filter(member=self.object)[:5]
         context['contracts'] = Contract.objects.filter(member=self.object)[:5]
+
+        page_user = self.object  # type: User
+        request_user = self.request.user  # type: User
+        same_gym_id = request_user.userprofile.gym_id == page_user.userprofile.gym_id
+        context['enable_login_button'] = request_user.has_perm('gym.gym_trainer') and same_gym_id
+        context['gym_name'] = request_user.userprofile.gym.name
         return context
 
 


### PR DESCRIPTION
I'm not the biggest fan of using native tooltips since they're so slow to render.
But I didn't see any other options being used in this project.

Deviated from bootstrap styles because I didn't feel their "disabled" state did
a very good job of communicating that the button is disabled.

I prefer leaving the button in place rather than hiding it so that users know
what is theoretically possible if they configure the system correctly.

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] New python code has been linted with with flake8 (``flake8 --config .github/linters/.flake8 ./wger``)
and isort (``isort``) 
- [x] Added yourself to AUTHORS.rst

# Before 
Button is enabled but takes you to a 404
![simplescreenrecorder-2021-03-07_20 45 28](https://user-images.githubusercontent.com/2147630/110269244-efc6e000-7f88-11eb-9b24-ddd3ca3e306f.gif)

# After
Button is disabled and shows a cursor/tooltip

https://user-images.githubusercontent.com/2147630/111019954-22f1e080-8388-11eb-9809-4185fca8d176.mp4

Fixes #585