### PR TITLE
Missing exercise name

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -53,6 +53,7 @@ Developers
 * Rachael Wright-Munn - https://github.com/ChaelCodes
 * Will Pearson - https://github.com/qagoose
 * Brad Johnson - https://github.com/bradsk88
+* Sidrah Madiha Siddiqui https://github.com/Sidrah-Madiha
 
 Translators
 -----------

--- a/wger/exercises/models.py
+++ b/wger/exercises/models.py
@@ -417,6 +417,7 @@ class Exercise(AbstractSubmissionModel, AbstractLicenseModel, models.Model):
         Set author and status
         This is only used when creating exercises (via web or API)
         """
+
         if request.user.has_perm('exercises.add_exercise'):
             self.status = self.STATUS_ACCEPTED
             if not self.license_author:
@@ -426,8 +427,9 @@ class Exercise(AbstractSubmissionModel, AbstractLicenseModel, models.Model):
                 self.license_author = request.user.username
 
             subject = _('New user submitted exercise')
+
             message = _('The user {0} submitted a new exercise "{1}".').format(
-                request.user.username, self.name)
+                request.user.username, self.name_original)
             mail.mail_admins(str(subject),
                              str(message),
                              fail_silently=True)


### PR DESCRIPTION
### Proposed Changes

  - Changed ```self.name``` to ```self.name_original``` in exercises/models.py in ```class Exercise```, fixes #617 
 @rolandgeider please review and approve my pull request, if there are no issues. Please let me know if there are problems within my PR, thanks.
Here is the demo of the fix working https://www.loom.com/share/d4f7667007b3424a81c7b3f3e6c2850a

### Please check that the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)     [No test needed, minor change]
- [ ] New python code has been linted with with flake8 (``flake8 --config .github/linters/.flake8 ./wger``) 
and isort (``isort``)          [minor change that didn't need formatting] 
- [x] Added yourself to AUTHORS.rst 

### Other questions

* Does this PR introduce a breaking change such as a database migration? (i.e.
what changes might users need to make in their running application due to
this PR?)
No