### PR TITLE
Added UI and credibility checks for users to upload exercise images

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -55,6 +55,8 @@ Developers
 * Brad Johnson - https://github.com/bradsk88
 * Sidrah Madiha Siddiqui https://github.com/Sidrah-Madiha
 * Calvin Walden - https://github.com/calvinrw
+* Emma Muth - https://github.com/emmaamuth
+* Sophia Reed - https://github.com/sophialr
 
 Translators
 -----------

--- a/wger/core/fixtures/users.json
+++ b/wger/core/fixtures/users.json
@@ -46,8 +46,8 @@
     },
     {
         "pk": 1,
-	"model": "core.usercache",
-	"fields": {
+	      "model": "core.usercache",
+	      "fields": {
             "last_activity": null,
             "user_id": 1
         }

--- a/wger/core/models.py
+++ b/wger/core/models.py
@@ -21,12 +21,12 @@ import decimal
 # Django
 from django.contrib.auth.models import (
     Permission,
-    User
+    User,
 )
 from django.core.exceptions import ValidationError
 from django.core.validators import (
     MaxValueValidator,
-    MinValueValidator
+    MinValueValidator,
 )
 from django.db import models
 from django.db.models import IntegerField
@@ -224,28 +224,27 @@ by the US Department of Agriculture. It is extremely complete, with around
     @property
     def is_trustworthy(self):
         """
-        Trustworthy if they've had an account for more than three weeks. More trustworthiness
-        criteria could be added in future.
+        Returns true for trustworthy if they've had an account for more than three weeks.
+        More trustworthiness criteria could be added in future.
         """
-        days_since_joined = datetime.date.today() - self.user.date_joined.date()
 
-        if days_since_joined.days > 21:
+        days_since_joined = datetime.date.today() - self.user.date_joined.date()
+        days_in_three_weeks = 21
+
+        if days_since_joined.days > days_in_three_weeks:
             # perms will be updated only once, after they hit three week mark
             image_perm = Permission.objects.get(codename='add_exerciseimage')
             self.user.user_permissions.add(image_perm)
 
-        return days_since_joined.days > 21
+        return days_since_joined.days > days_in_three_weeks
 
     @property
     def has_exercise_permission(self):
-        """
-        Returns true if user has all the exercise permissions and not just one.
-        """
-        if self.user.groups.filter(name='admin').exists() or \
-           self.user.groups.filter(name='exercises_editor').exists():
+        """Returns true if user has all the exercise permissions and not just one."""
+        if self.user.groups.filter(name='admin').exists() or self.user.groups.filter(
+                name='exercises_editor').exists():
             return True
-        else:
-            return False
+        return False
 
     #
     # User statistics

--- a/wger/core/models.py
+++ b/wger/core/models.py
@@ -19,7 +19,10 @@ import datetime
 import decimal
 
 # Django
-from django.contrib.auth.models import User
+from django.contrib.auth.models import (
+    Permission,
+    User
+)
 from django.core.exceptions import ValidationError
 from django.core.validators import (
     MaxValueValidator,
@@ -217,6 +220,32 @@ by the US Department of Agriculture. It is extremely complete, with around
     """
     Default duration of workout pauses in the gym view
     """
+
+    @property
+    def is_trustworthy(self):
+        """
+        Trustworthy if they've had an account for more than three weeks. More trustworthiness
+        criteria could be added in future.
+        """
+        days_since_joined = datetime.date.today() - self.user.date_joined.date()
+
+        if days_since_joined.days > 21:
+            # perms will be updated only once, after they hit three week mark
+            image_perm = Permission.objects.get(codename='add_exerciseimage')
+            self.user.user_permissions.add(image_perm)
+
+        return days_since_joined.days > 21
+
+    @property
+    def has_exercise_permission(self):
+        """
+        Returns true if user has all the exercise permissions and not just one.
+        """
+        if self.user.groups.filter(name='admin').exists() or \
+           self.user.groups.filter(name='exercises_editor').exists():
+            return True
+        else:
+            return False
 
     #
     # User statistics

--- a/wger/core/templates/navigation.html
+++ b/wger/core/templates/navigation.html
@@ -48,7 +48,7 @@
                             <li><a class="dropdown-item" href="{% url 'exercise:exercise:add' %}">{% translate "Add new exercise" %}</a><li>
                             {% endif %}
 
-                            {% if perms.exercises %}
+                            {% if user.userprofile.has_exercise_permission %}
                             <li class="dropdown-divider"></li>
                             <li class="dropdown-header">{% translate "Administration" %}</li>
                             <li><a class="dropdown-item" href="{% url 'exercise:exercise:pending' %}">{% translate "Exercises pending review" %}</a></li>
@@ -196,7 +196,7 @@
                                 {#                #}
                                 {# Administration #}
                                 {#                #}
-                                {% if perms.exercises or perms.gym.manage_gyms or perms.gym.manage_gym or perms.gym.gym_trainer %}
+                                {% if user.userprofile.has_exercise_permission or perms.gym.manage_gyms or perms.gym.manage_gym or perms.gym.gym_trainer %}
                                     <li class="dropdown-divider"></li>
                                     <li class="dropdown-header">{% translate "Administration" %}</li>
                                     {% if perms.core.change_language %}

--- a/wger/core/tests/test_temporary_users.py
+++ b/wger/core/tests/test_temporary_users.py
@@ -196,3 +196,18 @@ class DemoUserTestCase(WgerTestCase):
         self.assertEqual(self.count_temp_users(), 18)
         call_command('delete-temp-users')
         self.assertEqual(self.count_temp_users(), 2)
+
+    def test_temporary_user_no_permissions(self):
+        """
+        Tests that temporary users do not pass the "is trustworthy" check and do not have
+        any permissions.
+        """
+
+        # Get a temporary user
+        user = create_temporary_user()
+
+        # User does not pass trustworthiness check
+        self.assertFalse(user.userprofile.is_trustworthy)
+
+        # User does not pass admin/exercise editor permissions check
+        self.assertFalse(user.userprofile.has_exercise_permission)

--- a/wger/exercises/templates/exercise/form.html
+++ b/wger/exercises/templates/exercise/form.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 
-{% if not perms.exercises %}
+{% if not user.userprofile.has_exercise_permission %}
 <h4>{% translate "Submitting an exercise" %}</h4>
 <p><strong>{% blocktranslate %}Thank you for submitting an exercise. This is much
 appreciated!{% endblocktranslate %}</strong></p>

--- a/wger/exercises/templates/exercise/form_correct.html
+++ b/wger/exercises/templates/exercise/form_correct.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 
-{% if not perms.exercises %}
+{% if not user.userprofile.has_exercise_permission %}
 <h4>{% translate "Correcting an exercise" %}</h4>
 <p><strong>{% blocktranslate %}Thank you for correcting and improving this exercise.
 This is much appreciated!{% endblocktranslate %}</strong></p>

--- a/wger/exercises/templates/exercise/view.html
+++ b/wger/exercises/templates/exercise/view.html
@@ -92,7 +92,7 @@ $(document).ready(function() {
 
 {# Images #}
 {% with images=exercise.images.accepted %}
-{% if images or perms.exercises.change_exerciseimage  %}
+{% if images or perms.exercises.change_exerciseimage or user.userprofile.is_trustworthy %}
     <h5 class="mt-4">{% translate "Images" %}:</h5>
     <div class="row row-cols-2 row-cols-md-3">
     {% with other_images=images %}
@@ -131,7 +131,7 @@ $(document).ready(function() {
     {% endwith %}
     </div>
 
-    {% if perms.exercises.change_exerciseimage %}
+    {% if perms.exercises.change_exerciseimage or perms.exercises.add_exerciseimage or user.userprofile.is_trustworthy %}
         <p>
             <a href="{% url 'exercise:image:add' exercise.id %}" >
                 {% translate "Add new image" %}

--- a/wger/nutrition/templates/ingredient/form.html
+++ b/wger/nutrition/templates/ingredient/form.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 
-{% if not perms.exercises %}
+{% if not user.userprofile.has_exercise_permission %}
 <h4>{% translate "Submitting an ingredient" %}</h4>
 <p><strong>{% blocktranslate %}Thank you for submitting an ingredient. This is much
 appreciated!{% endblocktranslate %}</strong></p>

--- a/wger/utils/permissions.py
+++ b/wger/utils/permissions.py
@@ -62,7 +62,7 @@ class CreateOnlyPermission(permissions.BasePermission):
     """
     Custom permission that permits read access the resource but limits the
     write operations to creating (POSTing) new objects only and does not
-    allow allow editing them. This is currently used for exercises and their
+    allow editing them. This is currently used for exercises and their
     images.
     """
 


### PR DESCRIPTION
### Proposed Changes

  - Addresses Issue #599 
  - Now users who fulfill a trustworthiness criteria (has flexibility for additional criteria to be added) can add images to exercises without waiting for admin approval
  - In order to make the change above, updated several permissions checks to depend on the group a user is a part of instead of them having one or more exercise permissions because without that change a trustworthy user could view UI for all admin features
  - Also resolved small typo and indentation error

### Please check that the PR fulfills these requirements

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] New python code has been linted with with flake8 (``flake8 --config .github/linters/.flake8 ./wger``)
and isort (``isort``)
- [X] Added yourself to AUTHORS.rst

### Other questions

* Does this PR introduce a breaking change such as a database migration? (i.e.
what changes might users need to make in their running application due to
this PR?) No
