### PR TITLE
Add section for setting contrib.sites values in production installation docs

### DIFF
--- a/docs/production.rst
+++ b/docs/production.rst
@@ -166,6 +166,24 @@ Django provides a ``sendtestemail`` command via ``manage.py`` to test email sett
 
 .. _`Django's documentation`: https://docs.djangoproject.com/en/dev/topics/email/#email-backends
 
+.. _site-settings:
+
+Site Settings
+-------------
+
+Some wger features make use of Django's site name and domain settings in the ``contrib.sites`` framework. These should be set through the Python shell::
+
+   python manage.py shell
+   >>> from django.contrib.sites.models import Site
+   >>> site = Site.objects.get(pk=1)
+   >>> site.domain = 'wger.example.com'
+   >>> site.name = 'example.com wger Workout Manager'
+   >>> site.save()
+
+where ``wger.example.com`` is the domain of the wger instance. This assumes that wger is using the default site ID of 1. If a different site ID is being used, it must be specified in ``settings.py``::
+
+  SITE_ID = 2
+
 .. _other-changes:
 
 Other changes


### PR DESCRIPTION
### Proposed Changes

  - Add section to production.rst with instructions for setting site name and site domain in the `contrib.sites` framework. This was an early stumbling block for me when setting up my own wger instance, because the password reset email uses these values.

### Please check that the PR fulfills these requirements

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] New python code has been linted with with flake8 (``flake8 --config .github/linters/.flake8 ./wger``)
and isort (``isort``) 
- [X] Added yourself to AUTHORS.rst

### Other questions

* Does this PR introduce a breaking change such as a database migration? (i.e.
what changes might users need to make in their running application due to
this PR?)
No
