### PR TITLE
Solved bug in download-exercise-images.py task

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -57,6 +57,7 @@ Developers
 * Calvin Walden - https://github.com/calvinrw
 * Jack Mulligan - https://github.com/jackmulligan-ire
 * Kristopher Newsome - https://github.com/sysadmin75
+* Leninux - https://github.com/RedRudeBoy
 
 Translators
 -----------

--- a/wger/exercises/management/commands/download-exercise-images.py
+++ b/wger/exercises/management/commands/download-exercise-images.py
@@ -96,12 +96,6 @@ class Command(BaseCommand):
             self.stdout.write('')
             self.stdout.write(f'*** Page {page}')
             self.stdout.write('')
-            page += 1
-
-            if result['next']:
-                result = requests.get(result['next'], headers=headers).json()
-            else:
-                all_images_processed = True
 
             for image_data in result['results']:
                 image_uuid = image_data['uuid']
@@ -144,3 +138,9 @@ class Command(BaseCommand):
                 )
                 image.save()
                 self.stdout.write(self.style.SUCCESS('    successfully saved'))
+
+            if result['next']:
+                page += 1
+                result = requests.get(result['next'], headers=headers).json()
+            else:
+                all_images_processed = True


### PR DESCRIPTION
### Proposed Changes

  - This pull request solves a bug in download-exercise-images task, is a minor change, the "next" request is done before the first one is processed, so the first page was always ignored.

### Please check that the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features) - Not done
- [x] Added yourself to AUTHORS.rst