### PR TITLE
Correct typo in local docker demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ compose file. This config will persist your database and uploaded images:
 If you just want to try it out:
 
 ```shell script
-    docker run -ti --name wger.demo--publish 8000:80 wger/demo
+    docker run -ti --name wger.demo --publish 8000:80 wger/demo
 ```
 
 Then just open <http://localhost:8000> and log in as **admin**, password **adminadmin**


### PR DESCRIPTION
# Proposed Changes

- Fix a typo in the local docker demo snippet preventing spinup straight from copy/paste.

## Please check that the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Added yourself to AUTHORS.rst

Documentation update doesn't need a test.  
I'm not vain enough to give myself authorship for adding a space to the README, lol.

### Other questions

* Do users need to run some commmands in their local instances due to this PR
  (e.g. database migration)?

No.