### PR TITLE
Changes to prettify autocomplete and found an error in demo

### DIFF
--- a/wger/core/static/css/workout-manager.css
+++ b/wger/core/static/css/workout-manager.css
@@ -161,6 +161,7 @@ tbody tr:hover td .editoptions {
 .no-hover a:hover,
 .no-hover:hover {
   background-color: transparent;
+  cursor: pointer;
 }
 
 
@@ -392,6 +393,7 @@ table.month td.session-good:hover {
   font-size: 18px;
 }
 
+/**/
 .autocomplete-suggestions {
   overflow: auto;
   border: 1px solid #cbd3dd;
@@ -400,7 +402,7 @@ table.month td.session-good:hover {
 
 .autocomplete-suggestion {
   overflow: hidden;
-  padding: 5px 15px;
+  padding: 5px 20px;
   white-space: nowrap;
 }
 
@@ -415,6 +417,7 @@ table.month td.session-good:hover {
 
 .autocomplete-group {
   background-color: #d3d7cf;
+  padding-left: 10px;
 }
 
 .autocomplete-group strong {

--- a/wger/core/static/js/wger-core.js
+++ b/wger/core/static/js/wger-core.js
@@ -496,6 +496,9 @@ function wgerInitEditSet() {
       $(this).val('');
       return false;
     }
+
+    // Add something to clear autocomplete on back button
+    // Something like $('form').trigger("reset");
   });
 
   // Mobile select box


### PR DESCRIPTION
# Proposed Changes

- Created an indent for suggestion category
- Pushed suggestion items a litter further to emphasize hierarchical structure of autocomplete suggestsions
- Found an issue (on the live site) where if you select an exercise from the autocomplete > hit the back button > try to click the search box again, it takes you straight to the exercise page again. Attempted to fix, but personally do not have enough web dev background to take up the task.
- Found an inconsistency between number of min characters for autocomplete in exercises by category and by equipment.

## Please check that the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Added yourself to AUTHORS.rst

### Other questions

* Do users need to run some commmands in their local instances due to this PR
  (e.g. database migration)?
-No