### PR TITLE
Add thumbnail images to autocomplete ingredients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ venv-wget
 
 # Dummy file for translations
 /wger/i18n.tpl
+
+# Local images folder
+/media

--- a/wger/nutrition/api/views.py
+++ b/wger/nutrition/api/views.py
@@ -177,7 +177,7 @@ def search(request):
             else:
                 image = None
                 thumbnail = None
-                
+
             ingredient_json = {
                 'value': ingredient.name,
                 'data': {

--- a/wger/nutrition/static/js/nutrition.js
+++ b/wger/nutrition/static/js/nutrition.js
@@ -95,6 +95,12 @@ function wgerInitIngredientAutocompleter() {
           });
         });
       });
+    },
+    formatResult: function (suggestion) {
+      if (suggestion.data.image_thumbnail) {
+        return '<div><img src="' + suggestion.data.image_thumbnail + '" /> ' + suggestion.value + '</div>';
+      }
+      return '<div>' + suggestion.value + '</div>';
     }
   });
 }

--- a/wger/nutrition/templates/ingredient/overview.html
+++ b/wger/nutrition/templates/ingredient/overview.html
@@ -20,6 +20,12 @@
                 minChars: 3,
                 onSelect: function (suggestion) {
                      window.location.href = '/nutrition/ingredient/' + suggestion.data.id + '/view/'
+                },
+                formatResult: function (suggestion) {
+                    if (suggestion.data.image_thumbnail) {
+                        return '<div><img src="' + suggestion.data.image_thumbnail + '" /> ' + suggestion.value + '</div>';
+                    }
+                    return '<div>' + suggestion.value + '</div>';
                 }
             });
         });


### PR DESCRIPTION
# Proposed Changes
- Finishing off #653 
- Adds the thumbnail image to ingredient results if provided
- Also added the media folder to gitignore. I can revert it, if not wanted. 

## Please check that the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features) - Planning on leaving this feature untested.
- [x] Added yourself to AUTHORS.rst

### Other questions

None

### Showcase

Query `http://127.0.0.1:8000/api/v2/ingredient/search?term=whole grain oats`
Returns
```
{
    "suggestions": [
        {
            "value": "100% whole grain oats quick 1-minute oats",
            "data": {
                "id": 9754,
                "name": "100% whole grain oats quick 1-minute oats",
                "image": "/media/ingredients/ab1abca2-d55f-4da7-b2ce-c759aa86f3f5/1d684f01-31f2-40d6-ad47-277abfb4a3a2.jpg",
                "image_thumbnail": "/media/ingredients/ab1abca2-d55f-4da7-b2ce-c759aa86f3f5/1d684f01-31f2-40d6-ad47-277abfb4a3a2.jpg.30x30_q85_crop-smart.jpg"
            }
        },
        {
            "value": "Old fashioned 100% whole grain oats, old fashioned",
            "data": {
                "id": 9749,
                "name": "Old fashioned 100% whole grain oats, old fashioned",
                "image": null,
                "image_thumbnail": null
            }
        }
    ]
}
```

Front end
![Screenshot from 2022-05-14 07-51-13](https://user-images.githubusercontent.com/24668318/168394245-86404d9a-cc7a-4c04-a2c6-ffa1e763114a.png)
And
![Screenshot from 2022-05-14 19-23-12](https://user-images.githubusercontent.com/24668318/168419796-4fed6273-1bcf-4b65-8411-c728c7a05e97.png)

