### PR TITLE
Fix add workout modal

### DIFF
--- a/wger/manager/forms.py
+++ b/wger/manager/forms.py
@@ -105,6 +105,14 @@ class DayForm(ModelForm):
         exclude = ('training', )
         widgets = {'day': TranslatedSelectMultiple()}
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.layout = Layout(
+            'description',
+            'day',
+        )
+
 
 class OrderedModelMultipleChoiceField(ModelMultipleChoiceField):
     """Ordered multiple choice field"""

--- a/wger/manager/views/day.py
+++ b/wger/manager/views/day.py
@@ -64,7 +64,7 @@ class DayView(WgerFormMixin, LoginRequiredMixin):
 
     def get_form(self, form_class=DayForm):
         """
-        Filter the days of the week that are alreeady used by other days
+        Filter the days of the week that are already used by other days
         """
 
         # Get the form


### PR DESCRIPTION
# Proposed Changes
- Adding a training day works via the pop up modal now.
- Was mentioned earlier by Shemiroth in the discord on March 27th in devs channel.

## Please check that the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features) - Not sure how to add a test for this.
- [X] Added yourself to AUTHORS.rst

### Other questions
* I think the issue was the combo box being rendered after the save button. Not 100% sure why this fixes it.

### Showcase
Old behaviour

https://user-images.githubusercontent.com/24668318/169680848-8c27fdf8-7066-41af-85b8-ea6ae9319fa4.mp4

New behaviour. Still has the same error page if you don't select a day

https://user-images.githubusercontent.com/24668318/169680952-c693d498-1b4c-476f-a0a0-0801c10e7591.mp4
