### PR TITLE
Alternate rendering in case of an invalid password reset link

### DIFF
--- a/wger/core/templates/form.html
+++ b/wger/core/templates/form.html
@@ -15,7 +15,11 @@
 {% block title %}{{title}}{% endblock %}
 
 {% block content %}
-    {% crispy form %}
+    {% if form %}
+        {% crispy form %}
+    {% else %}
+        Looks like you clicked on an invalid link. Please try again.
+    {% endif %}
 {% endblock %}
 
 


### PR DESCRIPTION
# Proposed Changes
- #1154 is occuring when uidb64 or the token is invalid in password reset link
- Added Alternate rendering in case of an invalid url to catch the error
- Fixes #1154 
