### PR TITLE
Registation testing

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -72,6 +72,7 @@ Developers
 * Mohammad Rafigh - https://github.com/mohammadrafigh
 * Bernardo Koen - https://github.com/BernardoKoen
 * Gabriel Liss - https://github.com/gabeliss
+* Alexandra Rhodes - https://github.com/arhodes130
 
 Translators
 -----------

--- a/wger/core/tests/test_registration.py
+++ b/wger/core/tests/test_registration.py
@@ -108,6 +108,64 @@ class RegistrationTestCase(WgerTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(count_before + 1, count_after)
 
+        # Password too short
+        registration_data['password1'] = 'abc123'
+        response = self.client.post(reverse('core:user:registration'), registration_data)
+        self.assertFalse(response.context['form'].is_valid())
+        self.user_logout()
+
+        # Password is "password" (commonly used)
+        registration_data['password1'] = 'password'
+        response = self.client.post(reverse('core:user:registration'), registration_data)
+        self.assertFalse(response.context['form'].is_valid())
+        self.user_logout()
+
+        # Password is entirely numeric
+        registration_data['password1'] = '123456789'
+        response = self.client.post(reverse('core:user:registration'), registration_data)
+        self.assertFalse(response.context['form'].is_valid())
+        self.user_logout()
+
+        # Passwords don't match
+        registration_data['password2'] = 'quai8fai7Zaeq'
+        response = self.client.post(reverse('core:user:registration'), registration_data)
+        self.assertFalse(response.context['form'].is_valid())
+        self.user_logout()
+
+        # First password is missing
+        registration_data['password1'] = ""
+        response = self.client.post(reverse('core:user:registration'), registration_data)
+        self.assertFalse(response.context['form'].is_valid())
+        self.user_logout()
+
+        # Second password is missing
+        registration_data['password2'] = ""
+        response = self.client.post(reverse('core:user:registration'), registration_data)
+        self.assertFalse(response.context['form'].is_valid())
+        self.user_logout()
+
+        # Username is too long
+        long_user = ("my_username_is_"
+                     "wayyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
+                     "_toooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+                     "_loooooooooooooooooooooooooooooooooooooooooooooooooooooooooong")
+        registration_data['username'] = long_user
+        response = self.client.post(reverse('core:user:registration'), registration_data)
+        self.assertFalse(response.context['form'].is_valid())
+        self.user_logout()
+
+        # Username contains invalid symbol
+        registration_data['username'] = "username!"
+        response = self.client.post(reverse('core:user:registration'), registration_data)
+        self.assertFalse(response.context['form'].is_valid())
+        self.user_logout()
+
+        # Username is missing
+        registration_data['username'] = ""
+        response = self.client.post(reverse('core:user:registration'), registration_data)
+        self.assertFalse(response.context['form'].is_valid())
+        self.user_logout()
+
     def test_registration_deactivated(self):
         """
         Test that with deactivated registration no users can register


### PR DESCRIPTION
# Proposed Changes

- Added additional unit tests to test_registation file to explicitly test the username and password standards defined on the registration page

## Please check that the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Added yourself to AUTHORS.rst

### Other questions

* Do users need to run some commmands in their local instances due to this PR
  (e.g. database migration)?
No
