### PR TITLE
Make sure entrypoint is chown'ed as well

### DIFF
--- a/extras/docker/development/Dockerfile
+++ b/extras/docker/development/Dockerfile
@@ -50,7 +50,7 @@ COPY ${DOCKER_DIR}/entrypoint.sh /home/wger/entrypoint.sh
 RUN chmod +x /home/wger/entrypoint.sh
 RUN pip3 install --no-cache /wheels/*
 
-RUN chown -R wger:wger .
+RUN chown -R wger:wger /home/wger
 
 USER wger
 RUN mkdir ~/media \


### PR DESCRIPTION
Was looking something unrelated, and noticed this. With the `.` you only chown the `WORKDIR`

# Proposed Changes

-
-
-

## Please check that the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Added yourself to AUTHORS.rst

### Other questions

* Do users need to run some commmands in their local instances due to this PR
  (e.g. database migration)?
