### PR TITLE
replace psycopg2-binary with psycopg2

### DIFF
--- a/extras/docker/base/Dockerfile
+++ b/extras/docker/base/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update \
       python3-pip \
       sqlite3 \
       wget \
+      libpq \
   && rm -rf /var/lib/apt/lists/* \
   && npm install -g yarn sass\
   && locale-gen en_US.UTF-8

--- a/extras/docker/base/Dockerfile
+++ b/extras/docker/base/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update \
       python3-pip \
       sqlite3 \
       wget \
-      libpq \
+      libpq5 \
   && rm -rf /var/lib/apt/lists/* \
   && npm install -g yarn sass\
   && locale-gen en_US.UTF-8

--- a/extras/docker/development/Dockerfile
+++ b/extras/docker/development/Dockerfile
@@ -21,7 +21,8 @@ RUN apt-get update \
       python3-dev \
       python3-pip \
       python3-wheel \
-      git
+      git \
+      libpq-dev
 
 # Build the necessary python wheels
 COPY requirements* ./

--- a/requirements_prod.txt
+++ b/requirements_prod.txt
@@ -6,6 +6,6 @@
 -r requirements.txt
 
 gunicorn~=20.1
-psycopg2-binary==2.9.5
+psycopg2==2.9.5
 django-redis==5.2.0
 


### PR DESCRIPTION
# Proposed Changes

- Although the arm64 image builds, django will crash because the psycopg2-binary is buggy (linked to the wrong library)
- To be able to fix this compiling psycopg2 during image build will do

## Please check that the PR fulfills these requirements

- [X] Tests for the changes have been added (for bug fixes / features) -> not in django
- [X] Added yourself to AUTHORS.rst -> no changes in django code

### Other questions

* Do users need to run some commmands in their local instances due to this PR
  (e.g. database migration)? -> No
