### PR TITLE
fixes #1278

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ target/
 
 # IDE
 .idea/
+.vscode/
 
 # External Libraries
 wger/core/static/yarn
@@ -66,6 +67,7 @@ node_modules
 # Virtual envs
 venv
 venv-wger
+.python-version
 
 # Dummy translation files to copy to react or flutter repo
 /wger/i18n.tsx
@@ -75,3 +77,6 @@ venv-wger
 /wger/app_en.arb
 /coverage.lcov
 /media/
+
+# macOS
+.DS_Store

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -74,6 +74,7 @@ Developers
 * Bernardo Koen - https://github.com/BernardoKoen
 * Gabriel Liss - https://github.com/gabeliss
 * Alexandra Rhodes - https://github.com/arhodes130
+* Ben Southcott - https://github.com/blsouthcott
 
 Translators
 -----------

--- a/wger/locale/es/LC_MESSAGES/django.po
+++ b/wger/locale/es/LC_MESSAGES/django.po
@@ -16,8 +16,8 @@ msgstr ""
 "Project-Id-Version: wger Workout Manager\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-06-06 11:42+0200\n"
-"PO-Revision-Date: 2023-04-22 02:47+0000\n"
-"Last-Translator: Sergio Varela <sergitroll9@gmail.com>\n"
+"PO-Revision-Date: 2023-06-11 13:50+0000\n"
+"Last-Translator: gallegonovato <fran-carro@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/wger/web/es/>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -1064,11 +1064,11 @@ msgstr "El equipo de %(site_name)s"
 
 #: core/templates/rest_framework/api.html:37
 msgid "request info"
-msgstr ""
+msgstr "solicitar información"
 
 #: core/templates/rest_framework/api.html:41
 msgid "response info"
-msgstr ""
+msgstr "información de la respuesta"
 
 #: core/templates/tags/pagination.html:7 core/templates/tags/pagination.html:11
 msgid "previous"
@@ -2128,10 +2128,8 @@ msgid "Biceps"
 msgstr "Bíceps"
 
 #: i18n.tpl:8
-#, fuzzy
-#| msgid "Body weight"
 msgid "Body Weight"
-msgstr "Peso corporal"
+msgstr "Peso"
 
 #: i18n.tpl:9
 msgid "Calves"
@@ -2174,10 +2172,8 @@ msgid "Kilometers"
 msgstr "Kilómetros"
 
 #: i18n.tpl:19
-#, fuzzy
-#| msgid "Kilometers"
 msgid "Kilometers Per Hour"
-msgstr "Kilómetros"
+msgstr "Kilómetros por hora"
 
 #: i18n.tpl:20
 msgid "Lats"
@@ -2197,7 +2193,7 @@ msgstr "Millas"
 
 #: i18n.tpl:24
 msgid "Miles Per Hour"
-msgstr ""
+msgstr "Millas por hora"
 
 #: i18n.tpl:25
 msgid "Minutes"
@@ -2205,7 +2201,7 @@ msgstr "Minutos"
 
 #: i18n.tpl:26
 msgid "Plates"
-msgstr ""
+msgstr "Platos"
 
 #: i18n.tpl:27
 msgid "Pull-up bar"
@@ -3873,35 +3869,27 @@ msgstr "Sí, eliminar"
 
 #: utils/models.py:51
 msgid "The original title of this object, if available"
-msgstr ""
+msgstr "El título original de este objeto, si está disponible"
 
 #: utils/models.py:57
 msgid "Link to original object, if available"
-msgstr ""
+msgstr "Enlace al objeto original, si está disponible"
 
 #: utils/models.py:63
-#, fuzzy
-#| msgid "Author"
 msgid "Author(s)"
-msgstr "Autor"
+msgstr "Autor(es)"
 
 #: utils/models.py:67
-#, fuzzy
-#| msgid ""
-#| "If you are not the author, enter the name or source here. This is needed "
-#| "for some licenses e.g. the CC-BY-SA."
 msgid "If you are not the author, enter the name or source here."
-msgstr ""
-"Si no eres el autor, ingresa el nombre del mismo o la fuente. Es necesario "
-"para algunas licencias, ej.: CC-BY-SA."
+msgstr "Si no es usted el autor, introduce aquí el nombre o la fuente."
 
 #: utils/models.py:71
 msgid "Link to author profile, if available"
-msgstr ""
+msgstr "Enlace al perfil del autor, si está disponible"
 
 #: utils/models.py:77
 msgid "Link to the original source, if this is a derivative work"
-msgstr ""
+msgstr "Enlace a la fuente original, si se trata de una obra derivada"
 
 #: utils/models.py:79
 msgid ""
@@ -3909,6 +3897,9 @@ msgid ""
 "work, but which also contains sufficient new, creative content to entitle it "
 "to its own copyright."
 msgstr ""
+"Tenga en cuenta que una obra derivada es aquella que no sólo se basa en una "
+"obra anterior, sino que además contiene suficiente contenido nuevo y "
+"creativo como para tener derecho a sus propios derechos de autor."
 
 #: utils/models.py:128
 msgid "Pending"

--- a/wger/nutrition/tests/test_plan.py
+++ b/wger/nutrition/tests/test_plan.py
@@ -208,7 +208,7 @@ class PlanCopyTestCase(WgerTestCase):
         meal_fields = ("name", "time", "order",)
         meal_item_fields = ("ingredient", "weight_unit", "order", "amount",)
 
-        # test each Plan object's fields are equal
+        # test each Plan's fields are equal
         for field in plan_fields:
             self.assertEqual(getattr(orig_plan, field), getattr(copied_plan, field))
 
@@ -216,14 +216,14 @@ class PlanCopyTestCase(WgerTestCase):
         copied_plan_meals = copied_plan.meal_set.all()
         
         for meal_cnt, orig_meal in enumerate(orig_plan_meals):
-            # test that the fields are equal for each Meal object for each Plan
+            # test that the fields are equal for each Meal for each Plan
             for field in meal_fields:
                 self.assertEqual(getattr(orig_meal, field), getattr(copied_plan_meals[meal_cnt], field))
 
             orig_plan_meal_items = orig_plan_meals[meal_cnt].mealitem_set.all()
             copied_plan_meal_items = copied_plan_meals[meal_cnt].mealitem_set.all()
 
-            # test that the fields are equal for each MealItem object for each Meal
+            # test that the fields are equal for each MealItem for each Meal
             for item_cnt, orig_meal_item in enumerate(orig_plan_meal_items):
                 for field in meal_item_fields:
                     self.assertEqual(getattr(orig_meal_item, field), getattr(copied_plan_meal_items[item_cnt], field))

--- a/wger/nutrition/tests/test_plan.py
+++ b/wger/nutrition/tests/test_plan.py
@@ -14,7 +14,7 @@
 # along with Workout Manager.  If not, see <http://www.gnu.org/licenses/>.
 
 # Django
-from django.urls import reverse
+from django.urls import reverse, resolve
 
 # wger
 from wger.core.tests import api_base_test
@@ -189,3 +189,41 @@ class PlanApiTestCase(api_base_test.ApiBaseResourceTestCase):
     private_resource = True
     special_endpoints = ('nutritional_values', )
     data = {'description': 'The description', 'language': 1}
+
+
+class PlanCopyTestCase(WgerTestCase):
+
+    def test_copy_plan(self):
+        """ 
+        Tests making a copy of a meal plan
+        """
+        self.user_login()
+        orig_plan = NutritionPlan.objects.get(pk=2)
+        response = self.client.get(reverse("nutrition:plan:copy", kwargs={"pk": 2}))
+        copied_plan_pk = int(resolve(response.url).kwargs["id"])
+        copied_plan = NutritionPlan.objects.get(pk=copied_plan_pk)
+
+        # fields for each object to test for equality
+        plan_fields = ("user", "language", "description", "has_goal_calories",)
+        meal_fields = ("name", "time", "order",)
+        meal_item_fields = ("ingredient", "weight_unit", "order", "amount",)
+
+        # test each Plan object's fields are equal
+        for field in plan_fields:
+            self.assertEqual(getattr(orig_plan, field), getattr(copied_plan, field))
+
+        orig_plan_meals = orig_plan.meal_set.all()
+        copied_plan_meals = copied_plan.meal_set.all()
+        
+        for meal_cnt, orig_meal in enumerate(orig_plan_meals):
+            # test that the fields are equal for each Meal object for each Plan
+            for field in meal_fields:
+                self.assertEqual(getattr(orig_meal, field), getattr(copied_plan_meals[meal_cnt], field))
+
+            orig_plan_meal_items = orig_plan_meals[meal_cnt].mealitem_set.all()
+            copied_plan_meal_items = copied_plan_meals[meal_cnt].mealitem_set.all()
+
+            # test that the fields are equal for each MealItem object for each Meal
+            for item_cnt, orig_meal_item in enumerate(orig_plan_meal_items):
+                for field in meal_item_fields:
+                    self.assertEqual(getattr(orig_meal_item, field), getattr(copied_plan_meal_items[item_cnt], field))

--- a/wger/nutrition/views/plan.py
+++ b/wger/nutrition/views/plan.py
@@ -16,7 +16,6 @@
 
 # Standard Library
 import logging
-from copy import deepcopy
 
 # Django
 from django.contrib.auth.decorators import login_required
@@ -42,8 +41,6 @@ from django.views.generic import (
     DeleteView,
     UpdateView,
 )
-
-from django.db import transaction
 
 # Third Party
 from reportlab.lib import colors


### PR DESCRIPTION
# Proposed Changes

- Added a test for the copy nutrition plan function/endpoint
- Refactored copy nutrition plan function to avoid potential race condition that occurs, causing meals and meal items not to be copied when creating a copy of the nutrition plan

Notes:
The way the function is currently written in the master branch, the newly added test does not pass. The test does pass with the changes in this branch.

I was able to reproduce the issue locally, but only inconsistently. I was able to reliably reproduce it by creating a new account, adding a plan, and trying to copy that plan. However, I wasn’t able to consistently reproduce the issue for established accounts.

When I stepped through the code with a debugger, I didn’t encounter the issue. So I think a race condition can occur where plan_copy and meal_copy are still referencing the original plan and meal objects, even though those objects should be updated with the primary key for the new database entry. I suspect that creating new objects using the values of the fields of the original objects more reliably avoids a potential race condition because there are two completely separate objects, whereas currently plan and plan_copy, and meal and meal_copy, each reference the same object. 

## Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Added yourself to AUTHORS.rst

### Other questions

* Do users need to run some commmands in their local instances due to this PR
  (e.g. database migration)? No
