### PR TITLE
Set DJANGO_DEBUG mode to True so static files will be served on the website during development.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -74,6 +74,7 @@ Developers
 * Bernardo Koen - https://github.com/BernardoKoen
 * Gabriel Liss - https://github.com/gabeliss
 * Alexandra Rhodes - https://github.com/arhodes130
+* Aggelos - https://github.com/AggelosK26
 
 Translators
 -----------

--- a/extras/docker/development/settings.py
+++ b/extras/docker/development/settings.py
@@ -8,8 +8,8 @@ from wger.settings_global import *
 import environ
 
 env = environ.Env(
-    # set casting, default value
-    DJANGO_DEBUG=(bool, False)
+    # If debug is not set to true js and css files won't load correctly
+    DJANGO_DEBUG=(bool, True)
 )
 
 # Use 'DEBUG = True' to get more details for server errors


### PR DESCRIPTION
…elopment

# Proposed Changes

In a production environment, when DEBUG mode is set to False in Django settings, static files will not be served by default. This means that JS and CSS files will not be loaded when accessing the website.

On the other hand, when DEBUG mode is set to True, which is typically used during development, Django's built-in development server will automatically serve static files. This ensures that the website can load the necessary JS, CSS, and other static files.

Enabling DEBUG mode makes it easier for newcomers as they won't have to manually set the DJANGO_DEBUG value to true for their wger website instance to load the static files.

## Please check that the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Added yourself to AUTHORS.rst

### Other questions

* Do users need to run some commmands in their local instances due to this PR
  No
