### PR TITLE
Dupli acc fix

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -74,6 +74,7 @@ Developers
 * Bernardo Koen - https://github.com/BernardoKoen
 * Gabriel Liss - https://github.com/gabeliss
 * Alexandra Rhodes - https://github.com/arhodes130
+* Jayanth Bontha - https://github.com/JayanthBontha
 
 Translators
 -----------

--- a/wger/core/forms.py
+++ b/wger/core/forms.py
@@ -196,7 +196,8 @@ class UserEmailForm(forms.ModelForm):
         if not email:
             return email
         try:
-            user = User.objects.get(email=email)
+            #Performs a case-insensitive lookup
+            user = User.objects.get(email__iexact=email)
             if user.email == self.instance.email:
                 return email
         except User.DoesNotExist:


### PR DESCRIPTION
This minor PR would fix the issue #1438.
The problem arises as there is a case-sensitive check for unique email while registration. Emails are case-insensitive.
Changes have been tested in development environment.
# Proposed Changes

- The uniqueness of the email should be checked with a case-insensitive query.


## Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Added yourself to AUTHORS.rst

### Other questions

*No extra commands are required.(No migrations)
