### PR TITLE
Copy plan fix

### DIFF
--- a/wger/nutrition/views/plan.py
+++ b/wger/nutrition/views/plan.py
@@ -202,7 +202,6 @@ def copy(request, pk):
     """
     Copy the nutrition plan
     """
-    logger.debug(request.user)
     plan = get_object_or_404(NutritionPlan, pk=pk, user=request.user)
 
     # Copy plan
@@ -211,7 +210,6 @@ def copy(request, pk):
     plan_copy = plan
     plan_copy.pk = None
     plan_copy.save()
-    
     # Copy the meals
     for meal in meals:
         meal_items = meal.mealitem_set.select_related()

--- a/wger/nutrition/views/plan.py
+++ b/wger/nutrition/views/plan.py
@@ -202,19 +202,19 @@ def copy(request, pk):
     """
     Copy the nutrition plan
     """
-
+    logger.debug(request.user)
     plan = get_object_or_404(NutritionPlan, pk=pk, user=request.user)
 
     # Copy plan
-    meals = plan.meal_set.all()
+    meals = plan.meal_set.select_related()
 
     plan_copy = plan
     plan_copy.pk = None
     plan_copy.save()
-
+    
     # Copy the meals
     for meal in meals:
-        meal_items = meal.mealitem_set.all()
+        meal_items = meal.mealitem_set.select_related()
 
         meal_copy = meal
         meal_copy.pk = None
@@ -226,7 +226,7 @@ def copy(request, pk):
             item_copy = item
             item_copy.pk = None
             item_copy.meal = meal_copy
-            item.save()
+            item_copy.save()
 
     # Redirect
     return HttpResponseRedirect(reverse('nutrition:plan:view', kwargs={'id': plan.id}))


### PR DESCRIPTION
# Proposed Changes
Fixed bug causing the Copy of nutrition plan to be empty ( issue #1278 )
-It was caused by lazy querying of meals in the plan and the item copy not being saved properly. Fixed it by select_related().
-Optimal and reduces queries.

## Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Added yourself to AUTHORS.rst

### Other questions

* Do users need to run some commmands in their local instances due to this PR
  (e.g. database migration)?
No.
