### PR TITLE
Fixed the nutrition plan copy bug

### DIFF
--- a/wger/nutrition/views/plan.py
+++ b/wger/nutrition/views/plan.py
@@ -68,7 +68,7 @@ def copy(request, pk):
     plan = get_object_or_404(NutritionPlan, pk=pk, user=request.user)
 
     # Copy plan
-    meals = plan.meal_set.all()
+    meals = plan.meal_set.select_related()
 
     plan_copy = plan
     plan_copy.pk = None
@@ -76,7 +76,7 @@ def copy(request, pk):
 
     # Copy the meals
     for meal in meals:
-        meal_items = meal.mealitem_set.all()
+        meal_items = meal.mealitem_set.select_related()
 
         meal_copy = meal
         meal_copy.pk = None
@@ -88,7 +88,7 @@ def copy(request, pk):
             item_copy = item
             item_copy.pk = None
             item_copy.meal = meal_copy
-            item.save()
+            item_copy.save()
 
     # Redirect
     return HttpResponseRedirect(reverse('nutrition:plan:view', kwargs={'id': plan.id}))


### PR DESCRIPTION
# Proposed Changes

-Changed .all() to .set_related() , querying efficiently instead of lazyloading.
-Changed item.save() to item_copy.save() to correctly save the new nutrition plan 

## Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Added yourself to AUTHORS.rst

### Other questions

* Do users need to run some commmands in their local instances due to this PR
  (e.g. database migration)?
No
