### PR TITLE
Exercise comments are now editable

### DIFF
--- a/wger/manager/templates/set/edit.html
+++ b/wger/manager/templates/set/edit.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% load static %}
-{% load i18n static crispy_forms_tags %}
+
 
 <!--
         Title

--- a/wger/manager/templates/set/edit.html
+++ b/wger/manager/templates/set/edit.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% load static %}
-
+{% load i18n static crispy_forms_tags %}
 
 <!--
         Title
@@ -21,7 +21,11 @@
     {% for formset in formsets %}
         {% include 'set/formset.html' with base=formset.base formset=formset.formset helper=helper %}
     {% endfor %}
-
+    <div class="form-group">
+        <label for="id_comment" class="control-label">{% translate "Comment" %}:</label>
+        <input id="id_comment" name="comment" class="form-control" type="text" value="{{ comment }}">
+    </div>    
+    <br>
      <input type="submit" class="btn btn-primary btn-success btn-block" value="{% translate 'Update' %}">
 </form>
 {% endblock %}

--- a/wger/manager/views/set.py
+++ b/wger/manager/views/set.py
@@ -208,13 +208,13 @@ def edit(request, pk):
 
         if all_valid:
             for formset in formsets:
-                  instances = formset['formset'].save(commit=False)
+                instances = formset['formset'].save(commit=False)
 
-            for instance in instances:
-                # Double check that we are allowed to edit the set
-                if instance.get_owner_object().user != request.user:
-                    return HttpResponseForbidden()
-                instance.save()
+                for instance in instances:
+                    # Double check that we are allowed to edit the set
+                    if instance.get_owner_object().user != request.user:
+                        return HttpResponseForbidden()
+                    instance.save()
 
             return HttpResponseRedirect(
                 reverse('manager:workout:view', kwargs={'pk': set_obj.get_owner_object().id})

--- a/wger/manager/views/set.py
+++ b/wger/manager/views/set.py
@@ -192,6 +192,9 @@ def edit(request, pk):
         formsets.append({'base': base, 'formset': formset})
 
     if request.method == "POST":
+        set_obj.comment = request.POST.get('comment',"")  # Update the comment value for the Set object
+        set_obj.save()  # Save the changes to the Set object
+
         formsets = []
         for base in set_obj.exercise_bases:
             formset = SettingFormsetEdit(request.POST, prefix='exercise{0}'.format(base.id))
@@ -205,18 +208,18 @@ def edit(request, pk):
 
         if all_valid:
             for formset in formsets:
-                instances = formset['formset'].save(commit=False)
+                  instances = formset['formset'].save(commit=False)
 
-                for instance in instances:
-                    # Double check that we are allowed to edit the set
-                    if instance.get_owner_object().user != request.user:
-                        return HttpResponseForbidden()
-                    instance.save()
+            for instance in instances:
+                # Double check that we are allowed to edit the set
+                if instance.get_owner_object().user != request.user:
+                    return HttpResponseForbidden()
+                instance.save()
 
             return HttpResponseRedirect(
                 reverse('manager:workout:view', kwargs={'pk': set_obj.get_owner_object().id})
             )
 
     # Other context we need
-    context = {'formsets': formsets, 'helper': WorkoutLogFormHelper()}
+    context = {'formsets': formsets, 'helper': WorkoutLogFormHelper(),'comment': set_obj.comment }
     return render(request, 'set/edit.html', context)


### PR DESCRIPTION
# Proposed Changes

- Added feature to edit comment of exercises along with repetitions, solving issue#964 
- It is a little hacky but it works and error handling is done.

## Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Added yourself to AUTHORS.rst

### Other questions

* Do users need to run some commmands in their local instances due to this PR
  (e.g. database migration)?
No