### PR TITLE
EMAIL_USE_TLS or EMAIL_USE_SSL

### DIFF
--- a/extras/docker/development/settings.py
+++ b/extras/docker/development/settings.py
@@ -79,7 +79,7 @@ if os.environ.get("ENABLE_EMAIL"):
     EMAIL_HOST_USER = env.str("EMAIL_HOST_USER")
     EMAIL_HOST_PASSWORD = env.str("EMAIL_HOST_PASSWORD")
     EMAIL_USE_TLS = env.bool("EMAIL_USE_TLS", True)
-    EMAIL_USE_SSL = env.bool("EMAIL_USE_SSL", True)
+    EMAIL_USE_SSL = env.bool("EMAIL_USE_SSL", False)
     EMAIL_TIMEOUT = 60
 
 # Sender address used for sent emails


### PR DESCRIPTION
The default `settings.py` in the docker image has a error and gives the following Message:

```
ValueError: EMAIL_USE_TLS/EMAIL_USE_SSL are mutually exclusive, so only set one of those settings to True.
```

* EMAIL_USE_TLS is for starttls on the submission port
* EMAIL_USE_SSL is for the old dedicated ssl port

# Proposed Changes

- as most mailservers now use the submission port i suggest setting `EMAIL_USE_TLS` as a default.