### PR TITLE
Workout log improvements: cancel button and test

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -75,6 +75,7 @@ Developers
 * Gabriel Liss - https://github.com/gabeliss
 * Alexandra Rhodes - https://github.com/arhodes130
 * Jayanth Bontha - https://github.com/JayanthBontha
+* Sadena Rishindran - https://github.com/sadena27
 
 Translators
 -----------

--- a/wger/manager/templates/log/add.html
+++ b/wger/manager/templates/log/add.html
@@ -63,6 +63,7 @@ $(document).ready(function () {
     {% endfor %}
     <div class="form-group">
         <input type="submit" name="submit" value="{% translate 'Save' %}" class="btn btn-primary btn-success btn-block" id="submit-id-submit">
+        <a href="{% url 'manager:log:log' day.training_id %}"><input type="button" name="cancel" value="{% translate 'Cancel' %}" class="btn btn-primary btn-block"></a>
     </div>
 </form>
 {% endblock %}

--- a/wger/manager/tests/test_workout.py
+++ b/wger/manager/tests/test_workout.py
@@ -134,3 +134,34 @@ class WorkoutApiTestCase(api_base_test.ApiBaseResourceTestCase):
     private_resource = True
     special_endpoints = ('canonical_representation', )
     data = {'name': 'A new comment'}
+
+class AddWorkoutLogTestCase(WgerTestCase):
+    """
+    Tests adding log to a Workout
+    """
+
+    def create_workout_log(self):
+        """
+        Helper function to test creating workouts
+        """
+
+        # Create a workout
+        count_before = Workout.objects.log.count()
+        response = self.client.get(reverse('manager:log:add'))
+        count_after = Workout.objects.log.count()
+
+        # Test adding a log
+        self.assertGreater(count_after, count_before)
+
+        # Test accessing the workout log
+        response = self.client.get(reverse('manager:log:log', kwargs={'pk': 1}))
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_workout_logged_in(self):
+        """
+        Test creating a workout out log for a logged in user
+        """
+
+        self.user_login()
+        self.create_workout_log()
+        self.user_logout()


### PR DESCRIPTION
# Proposed Changes

- Added a cancel button to the add workout log page since it was previously unintuitive if you wanted to exit the form
- Added a test for adding a log to a workout to ensure it was done properly

## Please check that the PR fulfills these requirements

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Added yourself to AUTHORS.rst