### PR TITLE
Add progress bar to load-online-fixtures

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -75,6 +75,7 @@ Developers
 * Gabriel Liss - https://github.com/gabeliss
 * Alexandra Rhodes - https://github.com/arhodes130
 * Jayanth Bontha - https://github.com/JayanthBontha
+* Ethan Winters - https://github.com/ebwinters
 
 Translators
 -----------

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@
 # Application
 bleach[css]~=6.1
 crispy-bootstrap5==2023.10
+tqdm
 
 # this is a fork of django-bootstrap-breadcrumbs
 # we might need to think about migrating away from this completely

--- a/wger/core/management/commands/loaddata-progress.py
+++ b/wger/core/management/commands/loaddata-progress.py
@@ -1,0 +1,25 @@
+from django.core.management.commands.loaddata import Command as LoadDataCommand
+from django.core.management.base import BaseCommand, CommandError
+from tqdm import tqdm  # Assuming you have the tqdm library installed
+
+class Command(LoadDataCommand):
+    help = 'Load data from fixture files into the database with progress tracking.'
+
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+        parser.add_argument(
+            '--progress',
+            action='store_true',
+            dest='progress',
+            help='Show progress bar for loaddata process.',
+        )
+
+    def handle(self, *fixture_labels, **options):
+        fixture_labels = self.track_progress(fixture_labels)
+        super().handle(*fixture_labels, **options)
+
+    def track_progress(self, fixture_labels):
+        return tqdm(fixture_labels, desc='Loading fixtures', unit='fixture', ncols=80)
+
+# Usage example:
+# python manage.py custom_loaddata --progress my_fixture.json

--- a/wger/tasks.py
+++ b/wger/tasks.py
@@ -287,11 +287,6 @@ def load_online_fixtures(context, settings_path=None):
                 for data in response.iter_content(chunk_size=1024):
                     f.write(data)
                     pbar.update(len(data))
-
-
-        # f = tempfile.NamedTemporaryFile(delete=False, suffix='.json.zip')
-        # print(f'-> saving to temp file {f.name}')
-        # f.write(response.content)
         f.close()
         call_command("loaddata-progress", f.name)
         print('-> removing temp file')


### PR DESCRIPTION
# Proposed Changes
Adding a progress bar to `load-online-fixtures` command since it is unclear if progress is happening and leads to confusion when running the command as mentioned in [this issue from the docker repo](https://github.com/wger-project/docker/issues/76) 
- Use tqdm package
- Track progress on json download
- Use custom `loaddata` implementation to track progress on `loaddata` command
<img width="729" alt="image" src="https://github.com/wger-project/wger/assets/4297028/59b9a4be-f7e9-4c90-b884-78b6fa374043">


## Please check that the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Added yourself to AUTHORS.rst

### Other questions

* Do users need to run some commmands in their local instances due to this PR
  (e.g. database migration)?
No