### PR TITLE
Allow env specification of Redis connection SSL parameters

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -79,6 +79,7 @@ Developers
 * Ethan Winters - https://github.com/ebwinters
 * Dieter Plaetinck - https://github.com/Dieterbe
 * Jonathan La Field - https://github.com/JLaField
+* Taylor Fuller - https://github.com/taylor-fuller
 
 
 Translators

--- a/extras/docker/development/settings.py
+++ b/extras/docker/development/settings.py
@@ -111,6 +111,12 @@ if os.environ.get("DJANGO_CACHE_BACKEND"):
             'TIMEOUT': env.int("DJANGO_CACHE_TIMEOUT"),
             'OPTIONS': {
                 'CLIENT_CLASS': env.str("DJANGO_CACHE_CLIENT_CLASS"),
+                'CONNECTION_POOL_KWARGS': {
+                    "ssl_keyfile": env.str('DJANGO_CACHE_CLIENT_SSL_KEY_FILE', None),
+                    "ssl_certfile": env.str('DJANGO_CACHE_CLIENT_SSL_CERT_FILE', None),
+                    "ssl_cert_reqs": env.str('DJANGO_CACHE_CLIENT_SSL_CERT_REQS', 'required'),
+                    "ssl_check_hostname": env.str('DJANGO_CACHE_CLIENT_SSL_CHECK_HOSTNAME', False)
+                }
             }
         }
     }

--- a/extras/docker/development/settings.py
+++ b/extras/docker/development/settings.py
@@ -110,19 +110,33 @@ if os.environ.get("DJANGO_CACHE_BACKEND"):
             'LOCATION': env.str("DJANGO_CACHE_LOCATION"),
             'TIMEOUT': env.int("DJANGO_CACHE_TIMEOUT"),
             'OPTIONS': {
-                'CLIENT_CLASS': env.str("DJANGO_CACHE_CLIENT_CLASS"),
-                'CONNECTION_POOL_KWARGS': {
-                    "ssl_keyfile": env.str('DJANGO_CACHE_CLIENT_SSL_KEY_FILE', None),
-                    "ssl_certfile": env.str('DJANGO_CACHE_CLIENT_SSL_CERT_FILE', None),
-                    "ssl_cert_reqs": env.str('DJANGO_CACHE_CLIENT_SSL_CERT_REQS', 'required'),
-                    "ssl_check_hostname": env.str('DJANGO_CACHE_CLIENT_SSL_CHECK_HOSTNAME', False)
-                }
+                'CLIENT_CLASS': env.str("DJANGO_CACHE_CLIENT_CLASS")
             }
         }
     }
 
     if os.environ.get('DJANGO_CACHE_CLIENT_PASSWORD'):
         CACHES['default']['OPTIONS']['PASSWORD'] = env.str('DJANGO_CACHE_CLIENT_PASSWORD')
+
+    CONNECTION_POOL_KWARGS = dict()
+    if "DJANGO_CACHE_CLIENT_SSL_KEYFILE" in os.environ:
+        CONNECTION_POOL_KWARGS.update(
+            {"ssl_keyfile", env.str("DJANGO_CACHE_CLIENT_SSL_KEYFILE")})
+
+    if "DJANGO_CACHE_CLIENT_SSL_CERTFILE" in os.environ:
+        CONNECTION_POOL_KWARGS.update(
+            {"ssl_certfile", env.str("DJANGO_CACHE_CLIENT_SSL_CERTFILE")})
+
+    if "DJANGO_CACHE_CLIENT_SSL_CERT_REQS" in os.environ:
+        CONNECTION_POOL_KWARGS.update(
+            {"ssl_cert_reqs", env.str("DJANGO_CACHE_CLIENT_SSL_CERT_REQS")})
+
+    if "DJANGO_CACHE_CLIENT_SSL_CHECK_HOSTNAME" in os.environ:
+        CONNECTION_POOL_KWARGS.update(
+            {"ssl_check_hostname", env.bool("DJANGO_CACHE_CLIENT_SSL_CHECK_HOSTNAME")})
+
+    if len(CONNECTION_POOL_KWARGS) > 0:
+        CACHES["default"]["OPTIONS"]["CONNECTION_POOL_KWARGS"] = CONNECTION_POOL_KWARGS
 
 # Folder for compressed CSS and JS files
 COMPRESS_ROOT = STATIC_ROOT


### PR DESCRIPTION
# Proposed Changes
I decided to deploy this project in my Kubernetes cluster and it looks like by default there is no way to accept self-signed certificates when using TLS to connect to a Redis instance.

I am currently running a Redis instance on my local network requiring TLS for connections (setting `port 0` and `tls-port 6379` directives in `/etc/redis/redis.conf`) and using a self-signed cert. When attempting to connect to the Redis instance, `django-redis` is throwing the following error: 

`django_redis.exceptions.ConnectionInterrupted: Redis ConnectionError: Error 1 connecting to 192.168.xx.x:6379. [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate (_ssl.c:1007)`

After doing a quick search, I came across [this issue](https://github.com/jazzband/django-redis/issues/554) in `django-redis` that outlines the fix for this. Also, it does appear that configuration is outlined in the `django-redis` repo [README](https://github.com/jazzband/django-redis?tab=readme-ov-file#ssltls-and-self-signed-certificates) as well.

While I was adding this I figured it would be good to also include the ability to specify other possible common SSL configuration parameters as outlined [here](https://github.com/redis/redis-py/blob/master/redis/connection.py#L743-L760) in the `redis-py` project.

Assuming these changes are acceptable and once they are approved/merged I will open an accompanying PR in https://github.com/wger-project/docker to document these changes as well.

## Please check that the PR fulfills these requirements

- ~~[ ] Tests for the changes have been added (for bug fixes / features)~~ N/A given this is an env configuration
- [x] Added yourself to AUTHORS.rst
