### PR TITLE
Add basic OIDC integration with locally setup Authentik

### DIFF
--- a/wger/core/forms.py
+++ b/wger/core/forms.py
@@ -39,6 +39,7 @@ from django.utils.translation import gettext as _
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import (
     HTML,
+    Button,
     ButtonHolder,
     Column,
     Fieldset,
@@ -51,6 +52,10 @@ from django_recaptcha.widgets import ReCaptchaV3
 
 # wger
 from wger.core.models import UserProfile
+
+#OIDC
+from django.urls import reverse
+from django.shortcuts import redirect
 
 
 class UserLoginForm(AuthenticationForm):
@@ -67,6 +72,14 @@ class UserLoginForm(AuthenticationForm):
 
         self.helper = FormHelper()
         self.helper.add_input(Submit('submit', _('Login'), css_class='btn-success btn-block'))
+        self.helper.add_input(
+            Button(
+                'authentik_login',
+                _('Login with Authentik'),
+                css_class='btn btn-primary btn-block',
+                onclick=f"window.location.href='{reverse('oidc_authentication_init')}'"
+            )
+        )
         self.helper.form_class = 'wger-form'
         self.helper.layout = Layout(
             Row(
@@ -84,6 +97,7 @@ class UserLoginForm(AuthenticationForm):
 
         See https://github.com/wger-project/wger/issues/1163
         """
+
         if self.authenticate_on_clean:
             self.authenticate(self.request)
         return self.cleaned_data

--- a/wger/core/templates/base.html
+++ b/wger/core/templates/base.html
@@ -3,8 +3,6 @@
 
 {% block template %}
 
-
-
     {% if trainer_identity %}
         <div class="alert alert-info" style="margin-top: 1em;">
             {% blocktranslate with current_user=user|format_username %}You are

--- a/wger/core/templates/index.html
+++ b/wger/core/templates/index.html
@@ -1,7 +1,12 @@
 {% extends "base_wide.html" %}
 {% load i18n static wger_extras %}
 
-{% block title %}{% translate "Dashboard" %}{% endblock %}
+{% block title %}
+{% if user.is_authenticated %}
+    <p>Welcome, {{ user }}</p>
+{% endif %}
+{% translate "Dashboard" %}
+{% endblock %}
 
 {#        #}
 {# Header #}

--- a/wger/core/templates/user/login.html
+++ b/wger/core/templates/user/login.html
@@ -11,7 +11,6 @@
     {% crispy form %}
 {% endblock %}
 
-
 {% block sidebar %}
 <h4>{% translate "No account?" %}</h4>
 <p>

--- a/wger/core/urls.py
+++ b/wger/core/urls.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Affero General Public License
 
 # Django
+from django.contrib import admin
 from django.conf.urls import include
 from django.contrib.auth import views
 from django.urls import (

--- a/wger/core/views/user.py
+++ b/wger/core/views/user.py
@@ -207,8 +207,8 @@ def trainer_login(request, user_pk):
     # authentication backend
     if own:
         del request.session['trainer.identity']
+    # django_login(request, user, 'django.contrib.auth.backends.ModelBackend')
     django_login(request, user, 'django.contrib.auth.backends.ModelBackend')
-
     if not own:
         request.session['trainer.identity'] = orig_user_pk
         if request.GET.get('next'):

--- a/wger/settings_global.py
+++ b/wger/settings_global.py
@@ -20,6 +20,11 @@ import re
 import sys
 from datetime import timedelta
 
+# OIDC
+import environ
+env = environ.Env()
+environ.Env.read_env()
+
 # wger
 from wger import get_version
 from wger.utils.constants import DOWNLOAD_INGREDIENT_WGER
@@ -42,6 +47,8 @@ ROOT_URLCONF = 'wger.urls'
 WSGI_APPLICATION = 'wger.wsgi.application'
 
 INSTALLED_APPS = [
+    'mozilla_django_oidc',
+    'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.messages',
@@ -117,6 +124,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+
     # Prometheus
     'django_prometheus.middleware.PrometheusBeforeMiddleware',
 
@@ -127,6 +135,9 @@ MIDDLEWARE = [
 
     # Django Admin
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+
+    # middleware involving session and authentication must come first
+    'mozilla_django_oidc.middleware.SessionRefresh',
 
     # Javascript Header. Sends helper headers for AJAX
     'wger.utils.middleware.JavascriptAJAXRedirectionMiddleware',
@@ -151,9 +162,10 @@ MIDDLEWARE = [
 ]
 
 AUTHENTICATION_BACKENDS = (
+    'mozilla_django_oidc.auth.OIDCAuthenticationBackend',
     'axes.backends.AxesStandaloneBackend',  # should be the first one in the list
     'django.contrib.auth.backends.ModelBackend',
-    'wger.utils.helpers.EmailAuthBackend',
+    'wger.utils.helpers.EmailAuthBackend'
 )
 
 TEMPLATES = [
@@ -206,6 +218,7 @@ EMAIL_SUBJECT_PREFIX = '[wger] '
 #
 LOGIN_URL = '/user/login'
 LOGIN_REDIRECT_URL = '/'
+
 
 #
 # Internationalization
@@ -587,3 +600,12 @@ ACTSTREAM_SETTINGS = {
 
 # Whether the application is being run regularly or during tests
 TESTING = len(sys.argv) > 1 and sys.argv[1] == 'test'
+
+# OIDC
+OIDC_RP_CLIENT_ID = env("OIDC_RP_CLIENT_ID")
+OIDC_RP_CLIENT_SECRET = env("OIDC_RP_CLIENT_SECRET")
+OIDC_OP_AUTHORIZATION_ENDPOINT = env("OIDC_OP_AUTHORIZATION_ENDPOINT")
+OIDC_OP_USER_ENDPOINT = env("OIDC_OP_USER_ENDPOINT")
+OIDC_OP_TOKEN_ENDPOINT = env("OIDC_OP_TOKEN_ENDPOINT")
+OIDC_RP_SIGN_ALGO = env('OIDC_RP_SIGN_ALGO')
+OIDC_OP_JWKS_ENDPOINT = env('OIDC_OP_JWKS_ENDPOINT')

--- a/wger/urls.py
+++ b/wger/urls.py
@@ -16,6 +16,7 @@
 # along with Workout Manager.  If not, see <http://www.gnu.org/licenses/>.
 
 # Django
+from django.contrib import admin
 from django.conf import settings
 from django.conf.urls import include
 from django.conf.urls.i18n import i18n_patterns
@@ -217,6 +218,8 @@ sitemaps = {
 # The actual URLs
 #
 urlpatterns = i18n_patterns(
+    path('oidc/', include('mozilla_django_oidc.urls')),
+    path('admin/', admin.site.urls),
     path('', include(('wger.core.urls', 'core'), namespace='core')),
     path('routine/', include(('wger.manager.urls', 'manager'), namespace='manager')),
     path('exercise/', include(('wger.exercises.urls', 'exercise'), namespace='exercise')),
@@ -251,7 +254,7 @@ urlpatterns += [
     path('api/v2/', include(router.urls)),
     # The api user login
     path(
-        'api/v2/login/', core_api_views.UserAPILoginView.as_view({'post': 'post'}), name='api_user'
+        'api/v2/    /', core_api_views.UserAPILoginView.as_view({'post': 'post'}), name='api_user'
     ),
     path(
         'api/v2/register/',


### PR DESCRIPTION
# NOTE: Since this requires local manual setup of an OIDC IDP, this should not be merged into master but into its own branch (e.g. 'OIDC').

Addresses #1797 

# Proposed Changes

- Added a very basic form of OIDC Authentication support, by adding a "Login with Authentik" button to the Login page. It will authenticate with another (locally) spun-up Authentik IDP server, instead of requiring username/password combo. It will use the email of the user instead. 

## Please check that the PR fulfills these requirements

- [] Tests for the changes have been added (for bug fixes / features) - not sure how to test this, because this code review requires manual setup of an OAuth2 provider. 
- [ ] Added yourself to AUTHORS.rst

### Other questions

* Do users need to run some commmands in their local instances due to this PR
  (e.g. database migration)?

Yes. Users need to spin up an Authentik application of their own and then set these environment variables in the Django app (or hardcode them in settings_global.py: not recommended), values of which are provided by Authentik. 

OIDC_RP_CLIENT_ID
OIDC_RP_CLIENT_SECRET
OIDC_OP_AUTHORIZATION_ENDPOINT
OIDC_OP_TOKEN_ENDPOINT
OIDC_OP_USER_ENDPOINT
OIDC_OP_JWKS_ENDPOINT

They also need to set 
OIDC_RP_SIGN_ALGO=RS256



