### PR TITLE
Add language filter to sync-ingredients management command.

### DIFF
--- a/wger/core/management/commands/add-user-rest.py
+++ b/wger/core/management/commands/add-user-rest.py
@@ -32,14 +32,14 @@ class Command(BaseCommand):
                 user.userprofile.can_add_user = False
                 self.stdout.write(
                     self.style.SUCCESS(
-                        f"{options['name']} is now DISABLED from adding users via the API"
+                        f'{options["name"]} is now DISABLED from adding users via the API'
                     )
                 )
 
             else:
                 user.userprofile.can_add_user = True
                 self.stdout.write(
-                    self.style.SUCCESS(f"{options['name']} is now ALLOWED to add users via the API")
+                    self.style.SUCCESS(f'{options["name"]} is now ALLOWED to add users via the API')
                 )
             user.userprofile.save()
 

--- a/wger/core/management/commands/dummy-generator-users.py
+++ b/wger/core/management/commands/dummy-generator-users.py
@@ -65,7 +65,7 @@ class Command(BaseCommand):
     def handle(self, **options):
         faker = Faker()
 
-        self.stdout.write(f"** Generating {options['number_users']} users")
+        self.stdout.write(f'** Generating {options["number_users"]} users')
 
         match options['add_to_gym']:
             case 'auto':
@@ -80,7 +80,7 @@ class Command(BaseCommand):
             first_name = faker.first_name()
             last_name = faker.last_name()
 
-            username = slugify(f"{first_name}, {last_name} - {str(uid).split('-')[1]}")
+            username = slugify(f'{first_name}, {last_name} - {str(uid).split("-")[1]}')
             email = f'{username}@example.com'
             password = username
 

--- a/wger/core/models/profile.py
+++ b/wger/core/models/profile.py
@@ -116,7 +116,7 @@ class UserProfile(models.Model):
 
     show_comments = models.BooleanField(
         verbose_name=_('Show exercise comments'),
-        help_text=_('Check to show exercise comments on the ' 'workout view'),
+        help_text=_('Check to show exercise comments on the workout view'),
         default=True,
     )
     """
@@ -149,7 +149,7 @@ by the US Department of Agriculture. It is extremely complete, with around
 
     workout_reminder = IntegerField(
         verbose_name=_('Remind before expiration'),
-        help_text=_('The number of days you want to be reminded ' 'before a workout expires.'),
+        help_text=_('The number of days you want to be reminded before a workout expires.'),
         default=14,
         validators=[MinValueValidator(1), MaxValueValidator(30)],
     )
@@ -349,8 +349,8 @@ by the US Department of Agriculture. It is extremely complete, with around
     """Allow anonymous read-only access"""
 
     num_days_weight_reminder = models.IntegerField(
-        verbose_name=_('Automatic reminders for weight ' 'entries'),
-        help_text=_('Number of days after the last ' 'weight entry (enter 0 to ' 'deactivate)'),
+        verbose_name=_('Automatic reminders for weight entries'),
+        help_text=_('Number of days after the last weight entry (enter 0 to deactivate)'),
         validators=[MinValueValidator(0), MaxValueValidator(30)],
         default=0,
     )

--- a/wger/exercises/api/serializers.py
+++ b/wger/exercises/api/serializers.py
@@ -374,7 +374,7 @@ class ExerciseTranslationSerializer(serializers.ModelSerializer):
                     ~Q(id=self.instance.pk), language=value['language']
                 ).exists():
                     raise serializers.ValidationError(
-                        f"There is already a translation for this exercise in {value['language']}"
+                        f'There is already a translation for this exercise in {value["language"]}'
                     )
             # Creating a new object
             # -> Check if the language already exists
@@ -383,7 +383,7 @@ class ExerciseTranslationSerializer(serializers.ModelSerializer):
                     exercise_base=value['exercise_base'], language=value['language']
                 ).exists():
                     raise serializers.ValidationError(
-                        f"There is already a translation for this exercise in {value['language']}"
+                        f'There is already a translation for this exercise in {value["language"]}'
                     )
 
         return super().validate(value)

--- a/wger/exercises/management/commands/download-exercise-videos.py
+++ b/wger/exercises/management/commands/download-exercise-videos.py
@@ -44,7 +44,7 @@ class Command(BaseCommand):
             action='store',
             dest='remote_url',
             default='https://wger.de',
-            help='Remote URL to fetch the exercises from (default: ' 'https://wger.de)',
+            help='Remote URL to fetch the exercises from (default: https://wger.de)',
         )
 
     def handle(self, **options):

--- a/wger/exercises/sync.py
+++ b/wger/exercises/sync.py
@@ -88,7 +88,7 @@ def sync_exercises(
             uuid=uuid,
             defaults={'category_id': category_id, 'created': created},
         )
-        print_fn(f"{'created' if base_created else 'updated'} exercise {uuid}")
+        print_fn(f'{"created" if base_created else "updated"} exercise {uuid}')
 
         base.muscles.set(muscles)
         base.muscles_secondary.set(muscles_sec)
@@ -113,8 +113,8 @@ def sync_exercises(
                 },
             )
             out = (
-                f"- {'created' if translation_created else 'updated'} translation "
-                f"{translation.language.short_name} {trans_uuid} - {name}"
+                f'- {"created" if translation_created else "updated"} translation '
+                f'{translation.language.short_name} {trans_uuid} - {name}'
             )
             print_fn(out)
 
@@ -344,7 +344,7 @@ def handle_deleted_entries(
             try:
                 obj = Exercise.objects.get(uuid=uuid)
                 obj.delete()
-                print_fn(f"Deleted translation {uuid} ({data['comment']})")
+                print_fn(f'Deleted translation {uuid} ({data["comment"]})')
             except Exercise.DoesNotExist:
                 pass
 

--- a/wger/exercises/tests/test_categories.py
+++ b/wger/exercises/tests/test_categories.py
@@ -46,7 +46,7 @@ class CategoryOverviewTestCase(WgerAccessTestCase):
     user_success = 'admin'
     user_fail = (
         'manager1',
-        'manager2' 'general_manager1',
+        'manager2general_manager1',
         'manager3',
         'manager4',
         'test',

--- a/wger/exercises/tests/test_categories.py
+++ b/wger/exercises/tests/test_categories.py
@@ -46,7 +46,8 @@ class CategoryOverviewTestCase(WgerAccessTestCase):
     user_success = 'admin'
     user_fail = (
         'manager1',
-        'manager2general_manager1',
+        'manager2',
+        'general_manager1',
         'manager3',
         'manager4',
         'test',

--- a/wger/exercises/tests/test_exercise_translation.py
+++ b/wger/exercises/tests/test_exercise_translation.py
@@ -118,7 +118,7 @@ class MuscleTemplateTagTest(WgerTestCase):
         """
 
         context = Context({'muscles': Muscle.objects.get(pk=2)})
-        template = Template('{% load wger_extras %}' '{% render_muscles muscles %}')
+        template = Template('{% load wger_extras %}{% render_muscles muscles %}')
         rendered_template = template.render(context)
         self.assertIn('images/muscles/main/muscle-2.svg', rendered_template)
         self.assertNotIn('images/muscles/secondary/', rendered_template)
@@ -130,7 +130,7 @@ class MuscleTemplateTagTest(WgerTestCase):
         """
 
         context = Context({'muscles': Muscle.objects.get(pk=2), 'muscles_sec': []})
-        template = Template('{% load wger_extras %}' '{% render_muscles muscles muscles_sec %}')
+        template = Template('{% load wger_extras %}{% render_muscles muscles muscles_sec %}')
         rendered_template = template.render(context)
         self.assertIn('images/muscles/main/muscle-2.svg', rendered_template)
         self.assertNotIn('images/muscles/secondary/', rendered_template)
@@ -142,7 +142,7 @@ class MuscleTemplateTagTest(WgerTestCase):
         """
 
         context = Context({'muscles': Muscle.objects.get(pk=1)})
-        template = Template('{% load wger_extras %}' '{% render_muscles muscles_sec=muscles %}')
+        template = Template('{% load wger_extras %}{% render_muscles muscles_sec=muscles %}')
         rendered_template = template.render(context)
         self.assertIn('images/muscles/secondary/muscle-1.svg', rendered_template)
         self.assertNotIn('images/muscles/main/', rendered_template)
@@ -154,7 +154,7 @@ class MuscleTemplateTagTest(WgerTestCase):
         """
 
         context = Context({'muscles_sec': Muscle.objects.get(pk=1), 'muscles': []})
-        template = Template('{% load wger_extras %}' '{% render_muscles muscles muscles_sec %}')
+        template = Template('{% load wger_extras %}{% render_muscles muscles muscles_sec %}')
         rendered_template = template.render(context)
         self.assertIn('images/muscles/secondary/muscle-1.svg', rendered_template)
         self.assertNotIn('images/muscles/main/', rendered_template)
@@ -166,7 +166,7 @@ class MuscleTemplateTagTest(WgerTestCase):
         """
 
         context = Context({'muscles_sec': Muscle.objects.filter(is_front=True), 'muscles': []})
-        template = Template('{% load wger_extras %}' '{% render_muscles muscles muscles_sec %}')
+        template = Template('{% load wger_extras %}{% render_muscles muscles muscles_sec %}')
         rendered_template = template.render(context)
         self.assertIn('images/muscles/secondary/muscle-1.svg', rendered_template)
         self.assertNotIn('images/muscles/secondary/muscle-2.svg', rendered_template)
@@ -185,7 +185,7 @@ class MuscleTemplateTagTest(WgerTestCase):
                 'muscles': Muscle.objects.filter(id__in=[1, 4]),
             }
         )
-        template = Template('{% load wger_extras %}' '{% render_muscles muscles muscles_sec %}')
+        template = Template('{% load wger_extras %}{% render_muscles muscles muscles_sec %}')
         rendered_template = template.render(context)
         self.assertIn('images/muscles/main/muscle-1.svg', rendered_template)
         self.assertNotIn('images/muscles/main/muscle-2.svg', rendered_template)
@@ -202,7 +202,7 @@ class MuscleTemplateTagTest(WgerTestCase):
         """
 
         context = Context({'muscles': [], 'muscles_sec': []})
-        template = Template('{% load wger_extras %}' '{% render_muscles muscles muscles_sec %}')
+        template = Template('{% load wger_extras %}{% render_muscles muscles muscles_sec %}')
         rendered_template = template.render(context)
         self.assertEqual(rendered_template, '\n\n')
 
@@ -211,7 +211,7 @@ class MuscleTemplateTagTest(WgerTestCase):
         Test that the tag works when given no parameters
         """
 
-        template = Template('{% load wger_extras %}' '{% render_muscles %}')
+        template = Template('{% load wger_extras %}{% render_muscles %}')
         rendered_template = template.render(Context({}))
         self.assertEqual(rendered_template, '\n\n')
 

--- a/wger/exercises/tests/test_muscles.py
+++ b/wger/exercises/tests/test_muscles.py
@@ -52,7 +52,8 @@ class MuscleAdminOverviewTest(WgerAccessTestCase):
     user_success = 'admin'
     user_fail = (
         'manager1',
-        'manager2general_manager1',
+        'manager2',
+        'general_manager1',
         'manager3',
         'manager4',
         'test',

--- a/wger/exercises/tests/test_muscles.py
+++ b/wger/exercises/tests/test_muscles.py
@@ -52,7 +52,7 @@ class MuscleAdminOverviewTest(WgerAccessTestCase):
     user_success = 'admin'
     user_fail = (
         'manager1',
-        'manager2' 'general_manager1',
+        'manager2general_manager1',
         'manager3',
         'manager4',
         'test',

--- a/wger/gym/forms.py
+++ b/wger/gym/forms.py
@@ -95,9 +95,9 @@ class GymUserAddForm(GymUserPermissionForm, UserPersonalInformationForm):
         label=_('Username'),
         max_length=30,
         regex=r'^[\w.@+-]+$',
-        help_text=_('Required. 30 characters or fewer. Letters, digits and ' '@/./+/-/_ only.'),
+        help_text=_('Required. 30 characters or fewer. Letters, digits and @/./+/-/_ only.'),
         error_messages={
-            'invalid': _('This value may contain only letters, numbers and ' '@/.//-/_ characters.')
+            'invalid': _('This value may contain only letters, numbers and @/.//-/_ characters.')
         },
     )
 

--- a/wger/gym/management/commands/dummy-generator-gyms.py
+++ b/wger/gym/management/commands/dummy-generator-gyms.py
@@ -92,7 +92,7 @@ class Command(BaseCommand):
         faker.add_provider(gym_names_1)
         faker.add_provider(gym_names_2)
 
-        self.stdout.write(f"** Generating {options['number_gyms']} gyms")
+        self.stdout.write(f'** Generating {options["number_gyms"]} gyms')
 
         gym_list = []
         for i in range(options['number_gyms']):

--- a/wger/gym/models/user_config.py
+++ b/wger/gym/models/user_config.py
@@ -90,7 +90,7 @@ class GymUserConfig(AbstractGymUserConfigModel, m.Model):
 
     include_inactive = m.BooleanField(
         verbose_name=_('Include in inactive overview'),
-        help_text=_('Include this user in the email list with ' 'inactive members'),
+        help_text=_('Include this user in the email list with inactive members'),
         default=True,
     )
     """

--- a/wger/manager/management/commands/dummy-generator-workout-diary.py
+++ b/wger/manager/management/commands/dummy-generator-workout-diary.py
@@ -78,7 +78,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, **options):
-        self.stdout.write(f"** Generating {options['nr_diary_entries']} dummy diary entries")
+        self.stdout.write(f'** Generating {options["nr_diary_entries"]} dummy diary entries')
 
         users = (
             [User.objects.get(pk=options['user_id'])] if options['user_id'] else User.objects.all()

--- a/wger/manager/management/commands/dummy-generator-workout-plans.py
+++ b/wger/manager/management/commands/dummy-generator-workout-plans.py
@@ -61,7 +61,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, **options):
-        self.stdout.write(f"** Generating {options['nr_plans']} dummy workout plan(s) per user")
+        self.stdout.write(f'** Generating {options["nr_plans"]} dummy workout plan(s) per user')
 
         users = (
             [User.objects.get(pk=options['user_id'])] if options['user_id'] else User.objects.all()

--- a/wger/manager/models/schedule.py
+++ b/wger/manager/models/schedule.py
@@ -54,7 +54,7 @@ class Schedule(models.Model):
     name = models.CharField(
         verbose_name=_('Name'),
         max_length=100,
-        help_text=_('Name or short description of the schedule. ' "For example 'Program XYZ'."),
+        help_text=_("Name or short description of the schedule. For example 'Program XYZ'."),
     )
     """Name or short description of the schedule."""
 

--- a/wger/manager/models/session.py
+++ b/wger/manager/models/session.py
@@ -73,7 +73,7 @@ class WorkoutSession(models.Model):
         verbose_name=_('Notes'),
         null=True,
         blank=True,
-        help_text=_('Any notes you might want to save about this workout ' 'session.'),
+        help_text=_('Any notes you might want to save about this workout session.'),
     )
     """
     User notes about the workout
@@ -85,7 +85,7 @@ class WorkoutSession(models.Model):
         choices=IMPRESSION,
         default=IMPRESSION_NEUTRAL,
         help_text=_(
-            'Your impression about this workout session. ' 'Did you exercise as well as you could?'
+            'Your impression about this workout session. Did you exercise as well as you could?'
         ),
     )
     """

--- a/wger/manager/models/workout.py
+++ b/wger/manager/models/workout.py
@@ -72,7 +72,7 @@ class Workout(models.Model):
     is_template = models.BooleanField(
         verbose_name=_('Workout template'),
         help_text=_(
-            'Marking a workout as a template will freeze it and allow you to ' 'make copies of it'
+            'Marking a workout as a template will freeze it and allow you to make copies of it'
         ),
         default=False,
         null=False,

--- a/wger/manager/tests/test_set.py
+++ b/wger/manager/tests/test_set.py
@@ -483,7 +483,7 @@ class SetSmartReprTestCase(WgerTestCase):
         setting_text = set_obj.reps_smart_text(ExerciseBase.objects.get(pk=1))
         self.assertEqual(
             setting_text,
-            '8 (90 kg, 3 RiR) – 10 (80 kg, 2.5 RiR) – ' '10 (80 kg, 2 RiR) – 12 (80 kg, 1 RiR)',
+            '8 (90 kg, 3 RiR) – 10 (80 kg, 2.5 RiR) – 10 (80 kg, 2 RiR) – 12 (80 kg, 1 RiR)',
         )
 
     def test_synthetic_settings(self):

--- a/wger/measurements/management/commands/dummy-generator-measurement-categories.py
+++ b/wger/measurements/management/commands/dummy-generator-measurement-categories.py
@@ -67,7 +67,7 @@ class Command(BaseCommand):
 
     def handle(self, **options):
         self.stdout.write(
-            f"** Generating {options['nr_categories']} dummy measurement categories per user"
+            f'** Generating {options["nr_categories"]} dummy measurement categories per user'
         )
 
         users = (

--- a/wger/measurements/management/commands/dummy-generator-measurements.py
+++ b/wger/measurements/management/commands/dummy-generator-measurements.py
@@ -63,7 +63,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, **options):
-        self.stdout.write(f"** Generating {options['nr_measurements']} dummy measurements per user")
+        self.stdout.write(f'** Generating {options["nr_measurements"]} dummy measurements per user')
 
         users = (
             [User.objects.get(pk=options['user_id'])] if options['user_id'] else User.objects.all()

--- a/wger/nutrition/forms.py
+++ b/wger/nutrition/forms.py
@@ -206,16 +206,14 @@ class DailyCaloriesForm(forms.ModelForm):
 
     base_calories = forms.IntegerField(
         label=_('Basic caloric intake'),
-        help_text=_('Your basic caloric intake as calculated for ' 'your data'),
+        help_text=_('Your basic caloric intake as calculated for your data'),
         required=False,
         widget=Html5NumberInput(),
     )
     additional_calories = forms.IntegerField(
         label=_('Additional calories'),
         help_text=_(
-            'Additional calories to add to the base '
-            'rate (to substract, enter a negative '
-            'number)'
+            'Additional calories to add to the base rate (to substract, enter a negative number)'
         ),
         initial=0,
         required=False,

--- a/wger/nutrition/management/commands/dummy-generator-nutrition.py
+++ b/wger/nutrition/management/commands/dummy-generator-nutrition.py
@@ -80,7 +80,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, **options):
-        self.stdout.write(f"** Generating {options['nr_plans']} dummy nutritional plan(s) per user")
+        self.stdout.write(f'** Generating {options["nr_plans"]} dummy nutritional plan(s) per user')
 
         users = (
             [User.objects.get(pk=options['user_id'])] if options['user_id'] else User.objects.all()
@@ -147,6 +147,6 @@ class Command(BaseCommand):
                         diary_entries.append(log)
 
                 if int(options['verbosity']) >= 2:
-                    self.stdout.write(f"  created {options['nr_diary_dates']} diary entries")
+                    self.stdout.write(f'  created {options["nr_diary_dates"]} diary entries')
 
             LogItem.objects.bulk_create(diary_entries)

--- a/wger/nutrition/management/commands/sync-ingredients.py
+++ b/wger/nutrition/management/commands/sync-ingredients.py
@@ -49,7 +49,7 @@ class Command(BaseCommand):
             action='store',
             dest='languages',
             default=None,
-            help='Specify a comma-separated subset of languages to sync. Example: en,fr,es'
+            help='Specify a comma-separated subset of languages to sync. Example: en,fr,es',
         )
 
     def handle(self, **options):
@@ -59,7 +59,7 @@ class Command(BaseCommand):
         try:
             val = URLValidator()
             val(remote_url)
-            self.remote_url = remote_url     
+            self.remote_url = remote_url
         except ValidationError:
             raise CommandError('Please enter a valid URL')
         self.languages = languages

--- a/wger/nutrition/management/commands/sync-ingredients.py
+++ b/wger/nutrition/management/commands/sync-ingredients.py
@@ -43,15 +43,25 @@ class Command(BaseCommand):
             help=f'Remote URL to fetch the ingredients from (default: WGER_SETTINGS'
             f'["WGER_INSTANCE"] - {settings.WGER_SETTINGS["WGER_INSTANCE"]})',
         )
+        parser.add_argument(
+            '-l',
+            '--languages',
+            action='store',
+            dest='languages',
+            default=None,
+            help='Specify a comma-separated subset of languages to sync. Example: en,fr,es'
+        )
 
     def handle(self, **options):
         remote_url = options['remote_url']
+        languages = options['languages']
 
         try:
             val = URLValidator()
             val(remote_url)
-            self.remote_url = remote_url
+            self.remote_url = remote_url     
         except ValidationError:
             raise CommandError('Please enter a valid URL')
+        self.languages = languages
 
-        sync_ingredients(self.stdout.write, self.remote_url, self.style.SUCCESS)
+        sync_ingredients(self.stdout.write, self.remote_url, self.languages, self.style.SUCCESS)

--- a/wger/nutrition/management/commands/sync-ingredients.py
+++ b/wger/nutrition/management/commands/sync-ingredients.py
@@ -23,6 +23,7 @@ from django.core.validators import URLValidator
 
 # wger
 from wger.nutrition.sync import sync_ingredients
+from wger.utils.validators import validate_language_code
 
 
 class Command(BaseCommand):
@@ -62,6 +63,11 @@ class Command(BaseCommand):
             self.remote_url = remote_url
         except ValidationError:
             raise CommandError('Please enter a valid URL')
-        self.languages = languages
+        try:
+            self.languages = languages
+            for language in self.languages.split(','):
+                validate_language_code(language)
+        except ValidationError as e:
+            raise CommandError('\n'.join([str(arg) for arg in e.args if arg is not None]))
 
         sync_ingredients(self.stdout.write, self.remote_url, self.languages, self.style.SUCCESS)

--- a/wger/nutrition/management/commands/sync-ingredients.py
+++ b/wger/nutrition/management/commands/sync-ingredients.py
@@ -65,8 +65,9 @@ class Command(BaseCommand):
             raise CommandError('Please enter a valid URL')
         try:
             self.languages = languages
-            for language in self.languages.split(','):
-                validate_language_code(language)
+            if self.languages is not None:
+                for language in self.languages.split(','):
+                    validate_language_code(language)
         except ValidationError as e:
             raise CommandError('\n'.join([str(arg) for arg in e.args if arg is not None]))
 

--- a/wger/nutrition/models/plan.py
+++ b/wger/nutrition/models/plan.py
@@ -66,7 +66,7 @@ class NutritionPlan(models.Model):
         blank=True,
         verbose_name=_('Description'),
         help_text=_(
-            'A description of the goal of the plan, e.g. ' '"Gain mass" or "Prepare for summer"'
+            'A description of the goal of the plan, e.g. "Gain mass" or "Prepare for summer"'
         ),
     )
 

--- a/wger/nutrition/sync.py
+++ b/wger/nutrition/sync.py
@@ -233,6 +233,12 @@ def sync_ingredients(
                 server_url=remote_url,
                 query={'limit': API_MAX_ITEMS, 'language': language_id},
             )
+        else:
+            url = make_uri(
+                INGREDIENTS_ENDPOINT,
+                server_url=remote_url,
+                query={'limit': API_MAX_ITEMS},
+                )
         for data in get_paginated(url, headers=wger_headers()):
             uuid = data['uuid']
             name = data['name']

--- a/wger/nutrition/sync.py
+++ b/wger/nutrition/sync.py
@@ -15,7 +15,10 @@
 # Standard Library
 import logging
 import os
-from typing import List, Optional
+from typing import (
+    List,
+    Optional,
+)
 
 # Django
 from django.conf import settings
@@ -45,11 +48,11 @@ from wger.utils.constants import (
     DOWNLOAD_INGREDIENT_OFF,
     DOWNLOAD_INGREDIENT_WGER,
 )
+from wger.utils.language import load_language
 from wger.utils.requests import (
     get_paginated,
     wger_headers,
 )
-from wger.utils.language import load_language
 from wger.utils.url import make_uri
 
 
@@ -215,20 +218,21 @@ def download_ingredient_images(
         print_fn(style_fn('    successfully saved'))
 
 
-
-
-
 def sync_ingredients(
     print_fn,
     remote_url=settings.WGER_SETTINGS['WGER_INSTANCE'],
-    languages: Optional[str]=None,
-    style_fn=lambda x: x,    
+    languages: Optional[str] = None,
+    style_fn=lambda x: x,
 ):
-    """Synchronize the ingredients from the remote server"""    
-    
-    def _sync_ingredients(language_id: Optional[int]=None):
+    """Synchronize the ingredients from the remote server"""
+
+    def _sync_ingredients(language_id: Optional[int] = None):
         if language_id is not None:
-            url = make_uri(INGREDIENTS_ENDPOINT, server_url=remote_url, query={'limit': API_MAX_ITEMS, 'language': language_id})
+            url = make_uri(
+                INGREDIENTS_ENDPOINT,
+                server_url=remote_url,
+                query={'limit': API_MAX_ITEMS, 'language': language_id},
+            )
         for data in get_paginated(url, headers=wger_headers()):
             uuid = data['uuid']
             name = data['name']
@@ -257,10 +261,10 @@ def sync_ingredients(
                 },
             )
 
-            print_fn(f"{'created' if created else 'updated'} ingredient {uuid} - {name}")
+            print_fn(f'{"created" if created else "updated"} ingredient {uuid} - {name}')
 
     print_fn('*** Synchronizing ingredients...')
-    
+
     if languages is not None:
         language_ids: List[str] = []
         language_codes: List[str] = languages.split(',')
@@ -269,13 +273,14 @@ def sync_ingredients(
                 lang = load_language(language_code, default_to_english=False)
                 language_ids.append(lang.id)
             except Language.DoesNotExist as e:
-                print_fn(f'Error: The language code you provided ("{language_code}") does not exist in this database. Please try again.')
+                print_fn(
+                    f'Error: The language code you provided ("{language_code}") does not exist in this database. Please try again.'
+                )
                 return 0
-        
+
         for language_id in language_ids:
             _sync_ingredients(language_id)
     else:
         _sync_ingredients()
 
-    
     print_fn(style_fn('done!\n'))

--- a/wger/nutrition/sync.py
+++ b/wger/nutrition/sync.py
@@ -221,7 +221,7 @@ def download_ingredient_images(
 def sync_ingredients(
     print_fn,
     remote_url=settings.WGER_SETTINGS['WGER_INSTANCE'],
-    languages: Optional[str] = None,
+    language_codes: Optional[str] = None,
     style_fn=lambda x: x,
 ):
     """Synchronize the ingredients from the remote server"""
@@ -265,16 +265,17 @@ def sync_ingredients(
 
     print_fn('*** Synchronizing ingredients...')
 
-    if languages is not None:
-        language_ids: List[str] = []
-        language_codes: List[str] = languages.split(',')
-        for language_code in language_codes:
+    if language_codes is not None:
+        language_ids: List[int] = []
+        for code in language_codes.split(','):
+            # Leaving the try except in here even though we've already validated on the sync-ingredients command itself.
+            # This is in case we ever want to re-use this function for anything else where user can input language codes.
             try:
-                lang = load_language(language_code, default_to_english=False)
+                lang = load_language(code, default_to_english=False)
                 language_ids.append(lang.id)
             except Language.DoesNotExist as e:
                 print_fn(
-                    f'Error: The language code you provided ("{language_code}") does not exist in this database. Please try again.'
+                    f'Error: The language code you provided ("{code}") does not exist in this database. Please try again.'
                 )
                 return 0
 

--- a/wger/nutrition/tests/test_sync.py
+++ b/wger/nutrition/tests/test_sync.py
@@ -101,9 +101,9 @@ class TestSyncMethods(WgerTestCase):
         self.assertEqual(ingredient.code, '1234567890987654321')
 
         # Act
-        sync_ingredients(lambda x: x)
+        sync_ingredients(lambda x: x, language_codes='en')
         mock_request.assert_called_with(
-            'https://wger.de/api/v2/ingredient/?limit=999',
+            'https://wger.de/api/v2/ingredient/?limit=999&language=2',
             headers=wger_headers(),
         )
 

--- a/wger/tasks.py
+++ b/wger/tasks.py
@@ -258,7 +258,7 @@ def load_fixtures(context, settings_path=None):
     call_command('loaddata', 'gym-adminconfig.json')
 
 
-@task(help={'settings-path': 'Path to settings file (absolute path). Leave empty for ' 'default'})
+@task(help={'settings-path': 'Path to settings file (absolute path). Leave empty for default'})
 def load_online_fixtures(context, settings_path=None):
     """
     Downloads fixtures from server and installs them (at the moment only ingredients)

--- a/wger/utils/language.py
+++ b/wger/utils/language.py
@@ -28,7 +28,7 @@ from wger.utils.constants import ENGLISH_SHORT_NAME
 logger = logging.getLogger(__name__)
 
 
-def load_language(language_code=None):
+def load_language(language_code=None, default_to_english=True) -> Language:
     """
     Returns the currently used language, e.g. to load appropriate exercises
     """
@@ -44,8 +44,11 @@ def load_language(language_code=None):
 
     try:
         language = Language.objects.get(short_name=used_language)
-    except Language.DoesNotExist:
-        language = Language.objects.get(short_name=ENGLISH_SHORT_NAME)
+    except Language.DoesNotExist as e:
+        if default_to_english:
+            language = Language.objects.get(short_name=ENGLISH_SHORT_NAME)
+        else:
+            raise e
 
     cache.set(cache_mapper.get_language_key(language.short_name), language)
     return language

--- a/wger/utils/validators.py
+++ b/wger/utils/validators.py
@@ -1,0 +1,13 @@
+# Django
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+
+# wger
+from wger.core.models import Language
+
+
+def validate_language_code(value):
+    try:
+        language = Language.objects.get(short_name=value)
+    except Language.DoesNotExist:
+        raise ValidationError(_(f'{value} does not exist in this wger database.'))

--- a/wger/weight/management/commands/dummy-generator-body-weight.py
+++ b/wger/weight/management/commands/dummy-generator-body-weight.py
@@ -53,7 +53,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, **options):
-        self.stdout.write(f"** Generating {options['nr_entries']} weight entries per user")
+        self.stdout.write(f'** Generating {options["nr_entries"]} weight entries per user')
 
         base_weight = 80
 
@@ -61,7 +61,7 @@ class Command(BaseCommand):
             [User.objects.get(pk=options['user_id'])] if options['user_id'] else User.objects.all()
         )
 
-        print(f"** Generating {options['nr_entries']} weight entries per user")
+        print(f'** Generating {options["nr_entries"]} weight entries per user')
 
         for user in users:
             new_entries = []


### PR DESCRIPTION
# Proposed Changes

- Allow user to specify a language when syncing ingredients
- example: `python manage.py sync-ingredients --languages=en,fr,es`

## Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
  - `wger.nutrition.tests.test_xync.TestSyncMethods` has been slightly modified to ensure uri was called with proper filter.
- [x] Added yourself to AUTHORS.rst

### Other questions

* Do users need to run some commmands in their local instances due to this PR
  (e.g. database migration)? No
