### PR TITLE
Add Management Command for Async Ingredient Synchronization

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -85,6 +85,7 @@ Developers
 * eyJhb - https://github.com/eyJhb
 * Joshua Shelley - https://github.com/navyjosh
 * Matt Harrison - https://github.com/Maralai
+* Ali Rahbar - https://github.com/crypto-a
 
 
 Translators

--- a/wger/nutrition/management/commands/sync-all-ingredients-task.py
+++ b/wger/nutrition/management/commands/sync-all-ingredients-task.py
@@ -1,0 +1,14 @@
+# This file is part of wger Workout Manager.
+#
+# wger Workout Manager is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# wger Workout Manager is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+

--- a/wger/nutrition/management/commands/sync-ingredients-async.py
+++ b/wger/nutrition/management/commands/sync-ingredients-async.py
@@ -13,12 +13,18 @@
 # You should have received a copy of the GNU Affero General Public License
 
 from django.core.management.base import BaseCommand
+from wger.nutrition.tasks import sync_all_ingredients_task
 
 
 class Command(BaseCommand):
 
-    help = "Synchronize all ingredients from a remote wger instance to the local database"
+    help = "Asynchronously synchronize all ingredients from another wger instance."
 
     def handle(self, *args, **options):
 
-        self.stdout.write("Synchronizing all ingredients...")
+        self.stdout.write("Triggering the Celery task to synchronize all ingredients...")
+
+        # Trigger the task asynchronously
+        sync_all_ingredients_task.delay()
+
+        self.stdout.write("Synchronization task has been triggered. Check the Celery worker logs for progress.")

--- a/wger/nutrition/management/commands/sync-ingredients-async.py
+++ b/wger/nutrition/management/commands/sync-ingredients-async.py
@@ -12,3 +12,13 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+
+    help = "Synchronize all ingredients from a remote wger instance to the local database"
+
+    def handle(self, *args, **options):
+
+        self.stdout.write("Synchronizing all ingredients...")

--- a/wger/nutrition/tasks.py
+++ b/wger/nutrition/tasks.py
@@ -19,6 +19,7 @@ from random import (
     randint,
 )
 
+from celery import shared_task
 # Django
 from django.conf import settings
 from django.core.management import call_command
@@ -58,7 +59,7 @@ def fetch_all_ingredient_images_task():
     download_ingredient_images(logger.info)
 
 
-@app.task
+@shared_task
 def sync_all_ingredients_task():
     """
     Fetches the current ingredients from the default wger instance


### PR DESCRIPTION
# Proposed Changes (Issue #1862 )

- Added a new management command `python3 manage.py sync-ingredients-async` to trigger the asynchronous ingredient synchronization task (`sync_all_ingredients_task`) via Celery.
- Updated the `sync_all_ingredients_task` decorator from `@app.task` to `@shared_task` for accessing the task from the `manage.py` commands.

## Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Added yourself to AUTHORS.rst

### Other questions

* Do users need to run some commmands in their local instances due to this PR
  (e.g. database migration)?
- No, no additional commands or migrations are required.
