### PR TITLE
Clean apt temporary files in the base Docker image

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -87,6 +87,7 @@ Developers
 * Matt Harrison - https://github.com/Maralai
 * Ali Rahbar - https://github.com/crypto-a
 * Cam Cecil - https://github.com/scrapcode
+* Peter Dave Hello - https://github.com/PeterDaveHello
 
 
 Translators

--- a/extras/docker/base/Dockerfile
+++ b/extras/docker/base/Dockerfile
@@ -23,6 +23,7 @@ RUN apt update \
       wget \
       tzdata \
       libpq5 \
+  && rm -rf /var/lib/apt/lists/* \
   && locale-gen en_US.UTF-8
 
 # Environmental variables


### PR DESCRIPTION
# Proposed Changes

- Clean apt temporary list files in the base Docker image, it's kind of Dockerfile best practice.

## Please check that the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Added yourself to AUTHORS.rst

### Other questions

* Do users need to run some commmands in their local instances due to this PR
  - No
