### PR TITLE
Ensure trainers see their templates impersonating.

### DIFF
--- a/wger/gym/tests/test_routine.py
+++ b/wger/gym/tests/test_routine.py
@@ -1,0 +1,108 @@
+# This file is part of wger Workout Manager.
+#
+# wger Workout Manager is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# wger Workout Manager is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+
+# Standard Library
+import datetime
+
+# Django
+from django.urls import reverse
+
+# wger
+from wger.core.tests.base_testcase import WgerTestCase
+from wger.manager.models import Routine
+
+
+class RoutineApiTrainerTestCase(WgerTestCase):
+    """
+    Tests filtering routines in the api endpoint
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        Routine(
+            user_id=1,
+            name='Admin template',
+            is_template=True,
+            start=datetime.datetime.now(),
+            end=datetime.datetime.now() + datetime.timedelta(days=1),
+        ).save()
+
+    def test_routine_overview_user(self):
+        """A user can see their own routines"""
+
+        self.user_login('test')
+        request = self.client.get(reverse('routine-list'))
+        self.assertEqual(request.status_code, 200)
+
+        results = request.json()
+        self.assertEqual(results['count'], 4)
+
+    def test_routine_overview_admin(self):
+        """An admin can see their own routines"""
+
+        self.user_login('admin')
+        request = self.client.get(reverse('routine-list'))
+        self.assertEqual(request.status_code, 200)
+
+        results = request.json()
+        self.assertEqual(results['count'], 3)
+
+    def test_routine_overview_impersonating_admin(self):
+        """
+        When a trainer is impersonating a user, they can see the routines
+        from the user, plus their own.
+        """
+        self.user_login('admin')
+        self.client.get(reverse('core:user:trainer-login', kwargs={'user_pk': 2}))
+
+        request = self.client.get(reverse('routine-list'))
+        self.assertEqual(request.status_code, 200)
+
+        results = request.json()
+        self.assertEqual(results['count'], 6)
+
+    def test_routine_template_overview_user(self):
+        """A user can see their own routine templates"""
+
+        self.user_login('test')
+        request = self.client.get(reverse('templates-list'))
+        self.assertEqual(request.status_code, 200)
+
+        results = request.json()
+        self.assertEqual(results['count'], 1)
+
+    def test_routine_template_overview_admin(self):
+        """An admin can see their own routine templates"""
+
+        self.user_login('admin')
+        request = self.client.get(reverse('templates-list'))
+        self.assertEqual(request.status_code, 200)
+
+        results = request.json()
+        self.assertEqual(results['count'], 1)
+
+    def test_routine_template_overview_impersonating_admin(self):
+        """
+        When a trainer is impersonating a user, they can see the routines
+        from the user, plus their own.
+        """
+        self.user_login('admin')
+        self.client.get(reverse('core:user:trainer-login', kwargs={'user_pk': 2}))
+
+        request = self.client.get(reverse('templates-list'))
+        self.assertEqual(request.status_code, 200)
+
+        results = request.json()
+        self.assertEqual(results['count'], 2)

--- a/wger/manager/api/views.py
+++ b/wger/manager/api/views.py
@@ -14,13 +14,11 @@
 # along with Workout Manager.  If not, see <http://www.gnu.org/licenses/>.
 
 # Standard Library
-from datetime import datetime
 
 # Django
 from django.conf import settings
 from django.core.cache import cache
 from django.db.models import Q
-
 # Third Party
 from rest_framework import viewsets
 from rest_framework.decorators import action
@@ -114,7 +112,9 @@ class RoutineViewSet(viewsets.ModelViewSet):
         if getattr(self, 'swagger_fake_view', False):
             return Routine.objects.none()
 
-        return Routine.objects.filter(request_user_or_trainer_q(request=self.request) | Q(is_public=True))
+        return Routine.objects.filter(
+            request_user_or_trainer_q(request=self.request) | Q(is_public=True)
+        )
 
     def perform_create(self, serializer):
         """

--- a/wger/manager/api/views.py
+++ b/wger/manager/api/views.py
@@ -78,6 +78,16 @@ from wger.utils.cache import CacheKeyMapper
 from wger.utils.viewsets import WgerOwnerObjectModelViewSet
 
 
+def request_user_or_trainer_q(request):
+    """
+    Helper function to build a Q object for filtering objects by user or trainer.
+    """
+    trainer_identity_pk = request.session.get('trainer.identity', None)
+    if trainer_identity_pk:
+        return Q(user=request.user) | Q(user_id=trainer_identity_pk)
+    return Q(user=request.user)
+
+
 class RoutineViewSet(viewsets.ModelViewSet):
     """
     API endpoint for routine objects
@@ -104,7 +114,7 @@ class RoutineViewSet(viewsets.ModelViewSet):
         if getattr(self, 'swagger_fake_view', False):
             return Routine.objects.none()
 
-        return Routine.objects.filter(Q(user=self.request.user) | Q(is_public=True))
+        return Routine.objects.filter(request_user_or_trainer_q(request=self.request) | Q(is_public=True))
 
     def perform_create(self, serializer):
         """
@@ -213,7 +223,8 @@ class UserRoutineTemplateViewSet(viewsets.ReadOnlyModelViewSet):
         if getattr(self, 'swagger_fake_view', False):
             return Routine.objects.none()
 
-        return Routine.templates.filter(user=self.request.user)
+        # If the current user is a trainer, also return their templates.
+        return Routine.templates.filter(request_user_or_trainer_q(request=self.request))
 
 
 class PublicRoutineTemplateViewSet(viewsets.ReadOnlyModelViewSet):

--- a/wger/manager/views/routine.py
+++ b/wger/manager/views/routine.py
@@ -46,7 +46,11 @@ def copy_routine(request, pk):
     routine = get_object_or_404(Routine, pk=pk)
 
     if request.user != routine.user and not routine.is_public:
-        return HttpResponseForbidden()
+        # Check if the user is a trainer and the routine belongs to a client, only if it does not
+        # belong to the user.
+        trainer_identity_pk = request.session.get('trainer.identity', None)
+        if not trainer_identity_pk or routine.user.pk != trainer_identity_pk:
+            return HttpResponseForbidden()
 
     def copy_config(configs: List[AbstractChangeConfig], slot_entry: SlotEntry):
         for config in configs:


### PR DESCRIPTION
# Proposed Changes

- Add a helper for views to craft Q objects that cater for user or trainer
- Account for trainer when using the template (copying it back as an excercise)

## Related Issue(s)

No issue, this arises from a discord conversation.

## Please check that the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Code has been formatted to avoid unnecessary diffs (`ruff format && isort .`)

### Other questions

* I did not add tests yet, I would like some guidance on how to test this as template tests seem quite short.
