### PR TITLE
docs: Fix demo container name

### DIFF
--- a/extras/docker/demo/README.md
+++ b/extras/docker/demo/README.md
@@ -25,11 +25,11 @@ Then just open <http://localhost:8000> and log in as: **admin**, password **admi
 
 To stop the container:
 
-```sudo docker container stop wger.apache```
+```sudo docker container stop wger.demo```
 
 To start developing again:
 
-```sudo docker container start --attach wger.apache```
+```sudo docker container start --attach wger.demo```
 
 
 Building


### PR DESCRIPTION
# Proposed Changes

Updated the commands for stopping and starting the Docker container to use the correct container name `wger.demo` instead of `wger.apache`.

## Related Issue(s)

N/A

## Please check that the PR fulfills these requirements

N/A

### Other questions

N/A