### PR TITLE
Prevent height spinner going below 0 in user preferences

### DIFF
--- a/wger/core/forms.py
+++ b/wger/core/forms.py
@@ -142,6 +142,12 @@ class UserPreferencesForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(UserPreferencesForm, self).__init__(*args, **kwargs)
+
+        hattrs = self.fields['height'].widget.attrs
+        hattrs.setdefault('type', 'number')
+        hattrs.setdefault('step', '1')
+        hattrs['min'] = '0'
+
         self.helper = FormHelper()
         self.helper.form_class = 'wger-form'
         self.helper.layout = Layout(


### PR DESCRIPTION
# Proposed Changes

- Set min="0" (and type="number", step="1") on UserPreferencesForm height widget so the down arrow can not go below 0. 
- There is also a default prompt when the keyboard enters a negative number.

## Please check that the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Code has been formatted to avoid unnecessary diffs (`ruff format && isort .`)

### Other questions

* Do users need to run some commands in their local instances due to this PR
  (e.g. database migration, deployment changes)?
- None
