### PR TITLE
Make language dropdown scrollable (limit height; overflow-y:auto)

### DIFF
--- a/wger/core/static/css/language-menu.css
+++ b/wger/core/static/css/language-menu.css
@@ -1,0 +1,11 @@
+.language-menu{
+    max-height: 60vh;
+    overflow-y: auto;
+    width: min(92vw, 420px);
+    overscroll-behavior: contain;
+}
+
+.language-menu .dropdown-item{
+    padding: .5rem .75rem;
+}
+

--- a/wger/core/templates/template.html
+++ b/wger/core/templates/template.html
@@ -62,6 +62,8 @@
         id="react-css"
     >
 
+    <link rel="stylesheet" href="{% static 'css/language-menu.css' %}">
+
     <link rel="icon" href="{% static 'images/favicon.png' %}" type="image/png">
 
     {% compress js %}
@@ -209,7 +211,7 @@
                             <span class="caret"></span>
                         </button>
 
-                        <ul class="dropdown-menu" aria-labelledby="btnGroupLanguages">
+                        <ul class="dropdown-menu language-menu" aria-labelledby="btnGroupLanguages">
                             {% for language in languages %}
                                 {% language_select language %}
                             {% endfor %}


### PR DESCRIPTION
# Proposed Changes

- Make the language switcher dropdown scrollable to avoid being clipped on small viewports.
- Add a small, responsive CSS rule (`.language-menu`) to limit height and enable vertical scrolling:
  - `max-height: 60vh; overflow-y: auto; width: min(92vw, 420px); overscroll-behavior: contain;`

## Related Issue(s)
Closes #2040

## Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
        *N/A for this change: pure CSS/markup; verified manually with screenshots.*
<img width="1920" height="985" alt="2025-09-16_231925_801" src="https://github.com/user-attachments/assets/59d43550-19d5-4cad-964a-17015951a0aa" />
- [x] Code has been formatted to avoid unnecessary diffs (`ruff format && isort .`)

### Other questions

* Do users need to run some commands in their local instances due to this PR
  (e.g. database migration, deployment changes)?
No