### PR TITLE
Gallery: reuse exercise image validator to block animated uploads ( # 2054 ) 

### DIFF
--- a/wger/gallery/models/image.py
+++ b/wger/gallery/models/image.py
@@ -25,6 +25,9 @@ from django.db import models
 from django.dispatch import receiver
 from django.utils.translation import gettext_lazy as _
 
+# wger
+from wger.utils.images import validate_image_static_no_animation
+
 
 def gallery_upload_dir(instance, filename):
     """
@@ -53,6 +56,7 @@ class Image(models.Model):
         upload_to=gallery_upload_dir,
         height_field='height',
         width_field='width',
+        validators=[validate_image_static_no_animation],
     )
 
     height = models.IntegerField(editable=False)


### PR DESCRIPTION
**Summary**

Apply validate_image_static_no_animation to gallery uploads so animated images (e.g., animated WEBP) are rejected, aligning gallery behavior with exercises.

**What changed**

wger/gallery/models/image.py: added import and set validators=[validate_image_static_no_animation] on Image.image.



**Impact**

No schema changes, no migrations.

Frontend/API behavior unchanged except for validation feedback on invalid images.

**Testing**

Manually verified locally.

Unit tests not included in this PR per scope request.