### PR TITLE
Fixes "Get Started" button behavior on live site and adds "Already have an account?" link on registration page

### DIFF
--- a/wger/core/templates/form_content.html
+++ b/wger/core/templates/form_content.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load i18n static crispy_forms_tags %}
+{% load i18n static wger_extras crispy_forms_tags %}
 
 {% block header %}
     {{ form.media }}
@@ -26,4 +26,20 @@
 <!--
         Sidebar
 -->
-{% block sidebar %}{% if sidebar %}{% include sidebar %}{% endif %}{% endblock %}
+
+
+{% block sidebar %}
+    {% if sidebar %}
+        {% include sidebar %}
+    {% else %}
+        {% if user.is_anonymous %}
+            <h4>{% translate "Already have an account?" %}</h4>
+            <p>
+                <a href="{% url 'core:user:login' %}">
+                    <span class="{% fa_class 'sign-in-alt' %}"></span>
+                    {% translate "Login" %}
+                </a>
+            </p>
+        {% endif %}
+    {% endif %}
+{% endblock %}

--- a/wger/software/templates/features.html
+++ b/wger/software/templates/features.html
@@ -118,7 +118,7 @@
                        href="{% if user.is_authenticated %}
                                 {% url 'core:index' %}
                             {% else %}
-                                {% url 'core:user:login' %}
+                                {% url 'core:user:registration' %}
                             {% endif %}">
                         {% translate "Get Started" %}
                     </a>


### PR DESCRIPTION
## Proposed Changes

- Fixed the "Get Started" button on the live site to redirect to the registration page instead of login. (#2014)
- Added an "Already have an account?" link on the registration page that redirects to the login page.

## Related Issue(s)

- Closes #2014

## PR Checklist
- [x] My changes include only the intended updates.
- [x] No unnecessary files or large diffs are included.
- [x] Code follows the repository's formatting and style guidelines.

## Additional Notes

- No database migrations or additional commands are required for these changes.
- The {% if allow_registration %} condition on the login page remains unchanged as per project maintainer guidance.


### Other questions

* Do users need to run some commands in their local instances due to this PR
  (e.g. database migration, deployment changes)?
- No
