### PR TITLE
AVIF: updated supported images formats with avif

### DIFF
--- a/wger/utils/images.py
+++ b/wger/utils/images.py
@@ -46,5 +46,5 @@ def validate_image_static_no_animation(value):
         )
 
     # Check for animation
-    if img_format == 'webp' and getattr(img, 'is_animated'):
+    if img_format in ('webp', 'avif') and getattr(img, 'is_animated'):
         raise ValidationError('Animated images are not supported.')


### PR DESCRIPTION
# Changes Made

Currently we don't allow avif images to be uploaded, even if nothing speaks against it since all mayor browsers support it.

## Done:

- [x] check that pillow can read the format and if it does update validate_image_static_no_animation, make sure to disallow animations

## Related Issue(s)

[#2082](https://github.com/wger-project/wger/issues/2082)

## Demo Screenshots
<img width="1137" height="1320" alt="image" src="https://github.com/user-attachments/assets/81ef6b2d-3e76-408a-8044-da4c5dce2efd" />

## Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Set a 100 character limit in your editor/IDE to avoid white space diffs in the PR
  (run `dart format .`)
- [x] Updated/added relevant documentation (doc comments with `///`).
- [x] Added relevant reviewers.