### PR TITLE
Properly translate the strings

### DIFF
--- a/wger/core/forms.py
+++ b/wger/core/forms.py
@@ -34,6 +34,7 @@ from django.forms import (
     widgets,
 )
 from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy
 
 # Third Party
 from crispy_forms.helper import FormHelper
@@ -75,7 +76,7 @@ class UserLoginForm(AuthenticationForm):
     authenticate_on_clean = True
 
     def __init__(self, authenticate_on_clean=True, *args, **kwargs):
-        super(UserLoginForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # Apply custom password widget
         self.fields['password'].widget = PasswordInputWithToggle()
@@ -122,15 +123,15 @@ class UserLoginForm(AuthenticationForm):
 
 
 class UserPreferencesForm(forms.ModelForm):
-    first_name = forms.CharField(label=_('First name'), required=False)
-    last_name = forms.CharField(label=_('Last name'), required=False)
+    first_name = forms.CharField(label=gettext_lazy('First name'), required=False)
+    last_name = forms.CharField(label=gettext_lazy('Last name'), required=False)
     email = EmailField(
-        label=_('Email'),
-        help_text=_('Used for password resets and, optionally, e-mail reminders.'),
+        label=gettext_lazy('Email'),
+        help_text=gettext_lazy('Used for password resets and, optionally, e-mail reminders.'),
         required=False,
     )
     birthdate = forms.DateField(
-        label=_('Date of Birth'),
+        label=gettext_lazy('Date of Birth'),
         required=False,
         widget=forms.DateInput(
             attrs={
@@ -202,8 +203,8 @@ class UserPreferencesForm(forms.ModelForm):
 
 class UserEmailForm(forms.ModelForm):
     email = EmailField(
-        label=_('Email'),
-        help_text=_('Used for password resets and, optionally, email reminders.'),
+        label=gettext_lazy('Email'),
+        help_text=gettext_lazy('Used for password resets and, optionally, email reminders.'),
         required=False,
     )
 
@@ -253,14 +254,14 @@ class PasswordConfirmationForm(Form):
     """
 
     password = CharField(
-        label=_('Password'),
+        label=gettext_lazy('Password'),
         widget=PasswordInputWithToggle,
-        help_text=_('Please enter your current password.'),
+        help_text=gettext_lazy('Please enter your current password.'),
     )
 
     def __init__(self, user, data=None):
         self.user = user
-        super(PasswordConfirmationForm, self).__init__(data=data)
+        super().__init__(data=data)
         self.helper = FormHelper()
         self.helper.layout = Layout(
             'password',
@@ -285,11 +286,11 @@ class RegistrationForm(UserCreationForm, UserEmailForm):
     captcha = ReCaptchaField(
         widget=ReCaptchaV3,
         label='reCaptcha',
-        help_text=_('The form is secured with reCAPTCHA'),
+        help_text=gettext_lazy('The form is secured with reCAPTCHA'),
     )
 
     def __init__(self, *args, **kwargs):
-        super(RegistrationForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # Apply custom password widgets
         self.fields['password1'].widget = PasswordInputWithToggle()
@@ -316,7 +317,7 @@ class RegistrationFormNoCaptcha(UserCreationForm, UserEmailForm):
     """
 
     def __init__(self, *args, **kwargs):
-        super(RegistrationFormNoCaptcha, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # Apply custom password widgets
         self.fields['password1'].widget = PasswordInputWithToggle()
@@ -347,8 +348,8 @@ class FeedbackRegisteredForm(forms.Form):
     contact = forms.CharField(
         max_length=50,
         min_length=10,
-        label=_('Contact'),
-        help_text=_('Some way of answering you (e-mail, etc.)'),
+        label=gettext_lazy('Contact'),
+        help_text=gettext_lazy('Some way of answering you (e-mail, etc.)'),
         required=False,
     )
 
@@ -356,8 +357,8 @@ class FeedbackRegisteredForm(forms.Form):
         max_length=500,
         min_length=10,
         widget=widgets.Textarea,
-        label=_('Comment'),
-        help_text=_('What do you want to say?'),
+        label=gettext_lazy('Comment'),
+        help_text=gettext_lazy('What do you want to say?'),
         required=True,
     )
 
@@ -370,5 +371,5 @@ class FeedbackAnonymousForm(FeedbackRegisteredForm):
     captcha = ReCaptchaField(
         widget=ReCaptchaV3,
         label='reCaptcha',
-        help_text=_('The form is secured with reCAPTCHA'),
+        help_text=gettext_lazy('The form is secured with reCAPTCHA'),
     )


### PR DESCRIPTION
# Proposed Changes

We were using the eager gettext, which obviously wasn't working with class attributes, gettext_lazy makes sure that translated texts are actually shown in the correct language and not in English

## Related Issue(s)

Closes #2093 
