### PR TITLE
Add heart rate and duration fields to log model

### DIFF
--- a/wger/manager/models/log.py
+++ b/wger/manager/models/log.py
@@ -201,6 +201,31 @@ class WorkoutLog(models.Model):
     """
     Target Reps in Reserve
     """
+    bpm_max = models.PositiveIntegerField(
+        verbose_name=_('Bpm max.'),
+        blank=True,
+        null=True,
+    )
+    """
+    Logged maximum heart rate
+    """
+
+    bpm_avg = models.PositiveIntegerField(
+        verbose_name=_('Bpm (Ø)'),
+        blank=True,
+        null=True,
+    )
+    """
+    Logged average heart rate
+    """
+    duration = models.DurationField(
+        verbose_name=_('Duration'),
+        blank=True,
+        null=True,
+    )
+    """
+    Logged duration of the exercise (e.g. for cardio)
+    """
 
     rest = models.PositiveIntegerField(
         blank=True,


### PR DESCRIPTION
# Proposed Changes

- Added `bpm_max` (PositiveInteger), `bpm_avg` (PositiveInteger), and `duration` (DurationField) to the `WorkoutLog` model to allow tracking of cardio exercises.
- Updated `WorkoutLogSerializer` in `serializers.py` to expose these fields via the API.
- Added database migration files.

These fields are optional (`blank=True, null=True`), so they won't enforce data entry for strength training logs.

**Note:** I could not locate the `WorkoutLogForm` definition (it seems missing from `wger/manager/forms.py` in the current file structure). Therefore, this PR currently only enables these fields in the Backend and API, but **not yet in the classic Web UI**.

## Related Issue(s)

(If you have an issue number, replace this line with: Closes #YOUR_ISSUE_NUMBER. If not, you can delete this section.)

## Please check that the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Code has been formatted to avoid unnecessary diffs (`ruff format && isort .`)

### Other questions

* Do users need to run some commands in their local instances due to this PR
  (e.g. database migration, deployment changes)?

**Yes, database migrations are required:**
`python manage.py migrate`
