### PR TITLE
Add read-only weight summary and latest weight API endpoints

### DIFF
--- a/wger/weight/api/views.py
+++ b/wger/weight/api/views.py
@@ -9,14 +9,21 @@
 #
 # wger Workout Manager is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
 #
 # You should have received a copy of the GNU Affero General Public License
-# along with Workout Manager.  If not, see <http://www.gnu.org/licenses/>.
+# along with Workout Manager. If not, see <http://www.gnu.org/licenses/>.
 
 # Third Party
+from datetime import timedelta
+
+from django.db.models import Avg, Min, Max
+from django.utils.timezone import now
+
 from rest_framework import viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
 
 # wger
 from wger.weight.api.filtersets import WeightEntryFilterSet
@@ -25,37 +32,24 @@ from wger.weight.models import WeightEntry
 
 
 class WeightEntryViewSet(viewsets.ModelViewSet):
- """
-API endpoints for body weight tracking.
+    """
+    API endpoints for body weight tracking.
 
-Purpose:
-- Allow users to record body weight over time
-- Support monitoring of weight-loss or weight-gain progress
-- Enable data-driven fitness and nutrition adjustments
-
-Typical use cases:
-- Daily or weekly weight logging
-- Long-term progress tracking and trend analysis
-- Integration with nutrition and workout planning features
-
-This endpoint is commonly consumed by:
-- Mobile fitness applications
-- Health dashboards and analytics tools
-- Personal weight-management workflows
-"""
+    Allows users to record body weight over time and retrieve
+    aggregated statistics for progress analysis.
+    """
 
     serializer_class = WeightEntrySerializer
-
-    is_private = True
-    ordering_fields = '__all__'
     filterset_class = WeightEntryFilterSet
+    ordering_fields = "__all__"
+    is_private = True
 
     def get_queryset(self):
         """
         Only allow access to appropriate objects
         """
         # REST API generation
-        if getattr(self, 'swagger_fake_view', False):
+        if getattr(self, "swagger_fake_view", False):
             return WeightEntry.objects.none()
 
         return WeightEntry.objects.filter(user=self.request.user)
@@ -65,3 +59,49 @@ This endpoint is commonly consumed by:
         Set the owner
         """
         serializer.save(user=self.request.user)
+
+    @action(detail=False, methods=["get"])
+    def summary(self, request):
+        """
+        Returns summary statistics for the user's weight entries.
+
+        Includes:
+        - Total number of entries
+        - Current weight
+        - Average, minimum and maximum weight
+        - Weight change over time
+        - Trend direction
+        - Average weight for the last 30 days
+        """
+        qs = self.get_queryset().order_by("date")
+
+        if not qs.exists():
+            return Response({
+                "message": "No weight entries available"
+            })
+
+        first = qs.first().weight
+        last = qs.last().weight
+
+        last_30_days = qs.filter(
+            date__gte=now().date() - timedelta(days=30)
+        )
+
+        data = {
+            "total_entries": qs.count(),
+            "current_weight": last,
+            "average_weight": qs.aggregate(avg=Avg("weight"))["avg"],
+            "min_weight": qs.aggregate(min=Min("weight"))["min"],
+            "max_weight": qs.aggregate(max=Max("weight"))["max"],
+            "weight_change": last - first,
+            "trend": (
+                "up" if last > first else
+                "down" if last < first else
+                "stable"
+            ),
+            "average_last_30_days": last_30_days.aggregate(
+                avg=Avg("weight")
+            )["avg"],
+        }
+
+        return Response(data)

--- a/wger/weight/api/views.py
+++ b/wger/weight/api/views.py
@@ -105,3 +105,22 @@ class WeightEntryViewSet(viewsets.ModelViewSet):
         }
 
         return Response(data)
+            @action(detail=False, methods=["get"])
+    def latest(self, request):
+        """
+        Returns the most recent weight entry for the authenticated user.
+        """
+        qs = self.get_queryset().order_by("-date")
+
+        if not qs.exists():
+            return Response(
+                {"message": "No weight entries available"}
+            )
+
+        entry = qs.first()
+
+        return Response({
+            "date": entry.date,
+            "weight": entry.weight,
+        })
+

--- a/wger/weight/api/views.py
+++ b/wger/weight/api/views.py
@@ -25,9 +25,24 @@ from wger.weight.models import WeightEntry
 
 
 class WeightEntryViewSet(viewsets.ModelViewSet):
-    """
-    API endpoint for nutrition plan objects
-    """
+ """
+API endpoints for body weight tracking.
+
+Purpose:
+- Allow users to record body weight over time
+- Support monitoring of weight-loss or weight-gain progress
+- Enable data-driven fitness and nutrition adjustments
+
+Typical use cases:
+- Daily or weekly weight logging
+- Long-term progress tracking and trend analysis
+- Integration with nutrition and workout planning features
+
+This endpoint is commonly consumed by:
+- Mobile fitness applications
+- Health dashboards and analytics tools
+- Personal weight-management workflows
+"""
 
     serializer_class = WeightEntrySerializer
 

--- a/wger/weight/urls.py
+++ b/wger/weight/urls.py
@@ -16,6 +16,12 @@
 # along with Workout Manager.  If not, see <http://www.gnu.org/licenses/>.
 
 # Django
+
+
+from django.urls import include
+
+
+
 from django.contrib.auth.decorators import login_required
 from django.urls import (
     path,
@@ -29,6 +35,9 @@ from wger.weight.forms import WeightCsvImportForm
 
 
 urlpatterns = [
+
+    path('api/', include('wger.weight.api.urls')),
+
     path(
         'export-csv/',
         views.export_csv,
@@ -45,3 +54,4 @@ urlpatterns = [
         name='overview',
     ),
 ]
+


### PR DESCRIPTION
## Proposed Changes

- Added a read-only summary endpoint to the weight API
- Returns average, min, max, weight change and trend for user entries
- Exposed the endpoint via routing without affecting existing behavior

## Notes

- No existing logic was modified
- Endpoint is user-scoped and read-only
