### PR TITLE
Potential fix for code scanning alert no. 78: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ on:
 jobs:
   ci-job:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     env:
       DJANGO_SETTINGS_MODULE: settings.ci


### PR DESCRIPTION
Potential fix for [https://github.com/wger-project/wger/security/code-scanning/78](https://github.com/wger-project/wger/security/code-scanning/78)

In general, this issue is fixed by explicitly defining a `permissions` block either at the top level of the workflow (applies to all jobs without their own `permissions`) or within the specific job, granting only the scopes actually needed. For this CI workflow, all observed steps either read the repository contents or call external services; there is no need to push commits, create releases, or modify issues/PRs. Therefore, `contents: read` is a suitable minimal permission, and no additional write scopes appear necessary.

The single best fix without changing existing functionality is to add a job-level `permissions` block under `ci-job:` (or equivalently a workflow-level block at the root). To localize the change to the area CodeQL flagged, we’ll add:

```yaml
    permissions:
      contents: read
```

between `runs-on: ubuntu-latest` and `env:` for the `ci-job` job. No imports or other definitions are required, since this is purely a GitHub Actions workflow configuration change. The rest of the job definition and steps remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
