### PR TITLE
fix: prevent IntegrityError when deleting user account

### DIFF
--- a/wger/trophies/signals.py
+++ b/wger/trophies/signals.py
@@ -126,8 +126,17 @@ def workout_log_deleted(sender, instance: WorkoutLog, **kwargs):
     if not instance.user_id:
         return
 
+    # Django
+    from django.contrib.auth.models import User
+
     try:
+        # Check if user still exists before updating statistics
+        # This prevents errors when logs are deleted as part of user deletion
+        User.objects.get(id=instance.user_id)
         UserStatisticsService.handle_workout_deletion(instance.user)
+    except User.DoesNotExist:
+        # User was deleted - no need to update statistics
+        logger.debug(f'Skipping statistics update for deleted user {instance.user_id}')
     except Exception as e:
         logger.error(
             f'Error updating statistics after deletion for user {instance.user_id}: {e}',
@@ -177,8 +186,17 @@ def workout_session_deleted(sender, instance: WorkoutSession, **kwargs):
     if not instance.user_id:
         return
 
+    # Django
+    from django.contrib.auth.models import User
+
     try:
+        # Check if user still exists before updating statistics
+        # This prevents errors when sessions are deleted as part of user deletion
+        User.objects.get(id=instance.user_id)
         UserStatisticsService.handle_workout_deletion(instance.user)
+    except User.DoesNotExist:
+        # User was deleted - no need to update statistics
+        logger.debug(f'Skipping statistics update for deleted user {instance.user_id}')
     except Exception as e:
         logger.error(
             f'Error updating statistics after session deletion for user {instance.user_id}: {e}',


### PR DESCRIPTION
## Summary

Fixes the IntegrityError that occurs when a user deletes their account.

## Problem

When a user deletes their account, Django cascades the deletion to related objects (`WorkoutLog`, `WorkoutSession`). The `post_delete` signal handlers try to recalculate user statistics, but the user no longer exists at that point, causing an IntegrityError:

```
IntegrityError: insert or update on table "trophies_userstatistics" 
violates foreign key constraint "trophies_userstatistics_user_id_0de72480_fk_auth_user_id"
DETAIL: Key (user_id)=(....) is not present in table "auth_user".
```

## Solution

Added `User.DoesNotExist` checks in both delete signal handlers before attempting to update statistics:

- `workout_log_deleted()` - checks if user exists before recalculating
- `workout_session_deleted()` - checks if user exists before recalculating

If the user has been deleted, we skip the statistics update and log a debug message.

## Changes

- Modified `wger/trophies/signals.py`
  - Added User existence check in `workout_log_deleted`
  - Added User existence check in `workout_session_deleted`
  - Added debug logging when skipping updates for deleted users

## Testing

The fix handles the race condition where:
1. User deletion triggers cascade deletion of logs/sessions
2. Delete signals fire for each deleted object
3. Signal handlers check if user still exists
4. If user is deleted, skip statistics update gracefully

## Fixes

Fixes #2232