### PR TITLE
feat: Allow AUTH_PROXY_TRUSTED_IPS to accept subnetfeat: Allow AUTH_PROXY_TRUSTED_IPS to accept subnet via ipaddress module (#1989) (#1989)

### DIFF
--- a/wger/core/middleware.py
+++ b/wger/core/middleware.py
@@ -15,6 +15,8 @@
 # Standard Library
 import logging
 
+import ipaddress  # Support IP and CIDR subnet parsing
+
 # Django
 from django.conf import settings
 from django.contrib.auth import (
@@ -71,8 +73,28 @@ class AuthProxyHeaderMiddleware(MiddlewareMixin):
         # Use REMOTE_ADDR as it's the direct connection IP (should be the proxy).
         client_ip = request.META.get('REMOTE_ADDR')
 
-        # Check if the request comes from a trusted IP
-        if not client_ip or client_ip not in trusted_ips:
+
+        # Check if the request comes from a trusted IP or subnet
+        is_trusted = False
+        if client_ip:
+            try:
+                # Convert IP string to IP object
+                client_ip_obj = ipaddress.ip_address(client_ip)
+                for trusted_network in trusted_ips:
+                    try:
+                        # strict=False allows both single IPs (e.g., "192.168.1.1") 
+                        # and CIDR subnets (e.g., "192.168.1.0/24")
+                        if client_ip_obj in ipaddress.ip_network(trusted_network, strict=False):
+                            is_trusted = True
+                            break
+                    except ValueError:
+                        # Ignore invalid IP or subnet formats in settings
+                        pass
+            except ValueError:
+                # Invalid client IP format
+                pass
+
+        if not is_trusted:
             # If the header *is* present but the IP is not trusted, log a warning
             # as this might indicate a misconfiguration or security probing.
             if header_key in request.META:
@@ -82,7 +104,6 @@ class AuthProxyHeaderMiddleware(MiddlewareMixin):
                 )
             # Not a trusted IP, do nothing.
             return None
-
         username = request.META.get(header_key)
         email = request.META.get(user_email_key, '') if user_email_key else None
         name = request.META.get(user_name_key, '') if user_name_key else None

--- a/wger/core/tests/test_auth_proxy_middleware.py
+++ b/wger/core/tests/test_auth_proxy_middleware.py
@@ -180,3 +180,43 @@ class AuthProxyMiddlewareTests(TestCase):
         self.assertEqual(response_wrong1.status_code, 200)
         self.assertEqual(response_wrong2.status_code, 200)
         self.assertNotIn('_auth_user_id', self.client.session)
+
+    @override_settings(
+        AUTH_PROXY_TRUSTED_IPS=['10.0.0.0/24', TRUSTED_IP],
+        AUTH_PROXY_HEADER=PROXY_HEADER_KEY,
+        WGER_SETTINGS={'ALLOW_GUEST_USERS': False},
+    )
+    def test_success_trusted_ip_in_subnet(self):
+        """Client IP inside trusted CIDR subnet should authenticate."""
+        response = self.make_request('10.0.0.50', USERNAME)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(int(self.client.session.get('_auth_user_id', 0)), self.existing_user.pk)
+
+    @override_settings(
+        AUTH_PROXY_TRUSTED_IPS=['10.0.0.0/24', TRUSTED_IP],
+        AUTH_PROXY_HEADER=PROXY_HEADER_KEY,
+        WGER_SETTINGS={'ALLOW_GUEST_USERS': False},
+    )
+    def test_failure_untrusted_ip_outside_subnet(self):
+        """Client IP outside trusted CIDR subnet should not authenticate."""
+        response = self.make_request('10.0.1.50', USERNAME)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.request['PATH_INFO'].startswith(self.login_url))
+        self.assertNotIn('_auth_user_id', self.client.session)
+
+    @override_settings(
+        AUTH_PROXY_TRUSTED_IPS=['invalid_subnet_format', '10.0.0.0/24', TRUSTED_IP],
+        AUTH_PROXY_HEADER=PROXY_HEADER_KEY,
+        WGER_SETTINGS={'ALLOW_GUEST_USERS': False},
+    )
+    def test_graceful_handling_of_invalid_subnet_format(self):
+        """Invalid subnet entries should be ignored without crashing."""
+        response = self.make_request('10.0.0.50', USERNAME)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(int(self.client.session.get('_auth_user_id', 0)), self.existing_user.pk)
+
+        self.client.logout()
+
+        response_exact = self.make_request(TRUSTED_IP, USERNAME)
+        self.assertEqual(response_exact.status_code, 200)
+        self.assertEqual(int(self.client.session.get('_auth_user_id', 0)), self.existing_user.pk)


### PR DESCRIPTION
Hi @rolandgeider,

As discussed in #1989, this PR updates the AuthProxyHeaderMiddleware to support CIDR subnet notation for trusted proxy IPs.

Changes:

Imported the built-in ipaddress module.

Updated the IP matching logic in process_request to check if the client_ip belongs to any network defined in AUTH_PROXY_TRUSTED_IPS.

Used strict=False in ip_network to ensure backward compatibility (it works perfectly with both single IPs like 192.168.1.1 and subnets like 10.0.0.0/8).

Added basic try-except blocks to handle invalid formats gracefully without crashing the app.

Added 3 unit tests in test_auth_proxy_middleware.py to cover subnet matching, out-of-subnet rejection, and invalid config handling.

Fixes #1989.