### PR TITLE
feat: pre-select weight unit from user profile in routines

### DIFF
--- a/wger/manager/api/views.py
+++ b/wger/manager/api/views.py
@@ -417,6 +417,19 @@ class SlotEntryViewSet(WgerOwnerObjectModelViewSet):
         """
         return [(Slot, 'slot')]
 
+    def perform_create(self, serializer):
+        """
+        Default weight_unit to the user's preferred unit if not explicitly set.
+        """
+        if not serializer.validated_data.get('weight_unit'):
+            profile = self.request.user.userprofile
+            if profile.weight_unit == 'lb':
+                from wger.manager.consts import WEIGHT_UNIT_LB
+                from wger.core.models import WeightUnit
+
+                serializer.validated_data['weight_unit'] = WeightUnit.objects.get(pk=WEIGHT_UNIT_LB)
+        super().perform_create(serializer)
+
 
 class AbstractConfigViewSet(WgerOwnerObjectModelViewSet):
     """


### PR DESCRIPTION
Defaults weight_unit to the user's profile preference when creating slot entries.

## Why this matters

The default was always kg. Users who set their profile to pounds still got kg in new routine entries. Now the API respects their preference.

## Changes

- **wger/manager/api/views.py**: Added `perform_create` to `SlotEntryViewSet`. Checks if weight_unit is unset, then defaults to the user's profile preference. Only changes the default for `lb` users since `kg` is already the model default.

Note: This covers the web/API side. Flutter client changes for the same feature are separate.

## Testing

API call to create a slot entry without weight_unit now returns the user's preferred unit.

Fixes #2205

This contribution was developed with AI assistance (Claude Code).