### PR TITLE
feat(nutrition): allow range lookups on nutriscore ingredient filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
 # Changelog for the next release
 
+* The ingredient API filter now supports range lookups on `nutriscore`
+  (`gt`, `gte`, `lt`, `lte`) in addition to `exact` and `in`, enabling queries
+  like "better than C" (#2295).

--- a/wger/nutrition/api/filtersets.py
+++ b/wger/nutrition/api/filtersets.py
@@ -120,7 +120,7 @@ class IngredientFilterSet(filters.FilterSet):
             'sodium': ['exact'],
             'is_vegan': ['exact'],
             'is_vegetarian': ['exact'],
-            'nutriscore': ['exact', 'in'],
+            'nutriscore': ['exact', 'in', 'gt', 'gte', 'lt', 'lte'],
             'created': ['exact', 'gt', 'lt'],
             'last_update': ['exact', 'gt', 'lt'],
             'last_imported': ['exact', 'gt', 'lt'],

--- a/wger/nutrition/tests/test_search_api.py
+++ b/wger/nutrition/tests/test_search_api.py
@@ -96,3 +96,57 @@ class SearchIngredientApiTestCase(BaseTestCase, ApiBaseTestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 7)
+
+    def test_filter_nutriscore_exact(self):
+        """
+        Exact match on nutriscore returns only ingredients with that grade
+        """
+        response = self.client.get(self.url + '?nutriscore=a')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 3)
+
+    def test_filter_nutriscore_in(self):
+        """
+        `in` lookup accepts a comma-separated list of grades
+        """
+        response = self.client.get(self.url + '?nutriscore__in=a,b')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 7)
+
+    def test_filter_nutriscore_lt(self):
+        """
+        `lt` lookup returns ingredients with a better grade (e.g. better than C → A, B)
+        """
+        response = self.client.get(self.url + '?nutriscore__lt=c')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 7)
+
+    def test_filter_nutriscore_lte(self):
+        """
+        `lte` lookup is inclusive (e.g. C or better → A, B, C)
+        """
+        response = self.client.get(self.url + '?nutriscore__lte=c')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 10)
+
+    def test_filter_nutriscore_gt(self):
+        """
+        `gt` lookup returns ingredients with a worse grade (e.g. worse than C → D, E)
+        """
+        response = self.client.get(self.url + '?nutriscore__gt=c')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 3)
+
+    def test_filter_nutriscore_gte(self):
+        """
+        `gte` lookup is inclusive (e.g. C or worse → C, D, E)
+        """
+        response = self.client.get(self.url + '?nutriscore__gte=c')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 6)


### PR DESCRIPTION
## Summary
- Extend `IngredientFilterSet` so `nutriscore` accepts `gt`, `gte`, `lt`, `lte` lookups in addition to the existing `exact` and `in`. This enables range queries like "better than C" (`?nutriscore__lt=c`) that the React `IngredientAutocompleter` and Flutter `IngredientTypeahead` will consume.
- Since `nutriscore` is stored as a single lowercase character in the A–E range, lexicographic comparison on the `CharField` matches the grade ordering (A is best). `NULL` grades are excluded from range lookups by the Django ORM default, which matches expectations.
- Backend-only change — UI follow-up in `wger-project/react` and `wger-project/flutter` will be submitted separately.

Refs #2295 (blocker #2286 is merged).

## Test plan
- [x] New unit tests in `wger/nutrition/tests/test_search_api.py` covering `exact`, `in`, `lt`, `lte`, `gt`, `gte` on `nutriscore`
- [x] `uv run ./manage.py test wger.nutrition.tests.test_search_api` — 13 tests pass
- [x] `uv run ./manage.py test wger.nutrition` — 251 tests pass, no regressions
- [ ] Manual spot check via API: `GET /api/v2/ingredient/?nutriscore__lt=c` returns only A/B grades