### PR TITLE
fix: require change permission for exercise updates

### DIFF
--- a/wger/exercises/api/permissions.py
+++ b/wger/exercises/api/permissions.py
@@ -31,7 +31,8 @@ class CanContributeExercises(BasePermission):
     """
 
     SAFE_METHODS = ['GET', 'HEAD', 'OPTIONS']
-    ADD_METHODS = ['POST', 'PUT', 'PATCH']
+    ADD_METHODS = ['POST']
+    CHANGE_METHODS = ['PUT', 'PATCH']
     DELETE_METHODS = ['DELETE']
 
     def has_permission(self, request, view):
@@ -49,6 +50,13 @@ class CanContributeExercises(BasePermission):
                 'exercises.add_exercise'
             )
 
+        if request.method in self.CHANGE_METHODS:
+            return request.user.userprofile.is_trustworthy or request.user.has_perm(
+                'exercises.change_exercise'
+            )
+
         # Only admins are allowed to delete entries
         if request.method in self.DELETE_METHODS:
             return request.user.has_perm('exercises.delete_exercise')
+
+        return False

--- a/wger/exercises/tests/api/test_permissions.py
+++ b/wger/exercises/tests/api/test_permissions.py
@@ -1,0 +1,45 @@
+# Standard Library
+from unittest import mock
+
+# Django
+from django.test import SimpleTestCase
+
+# wger
+from wger.exercises.api.permissions import CanContributeExercises
+
+
+def build_request(method: str, *, is_authenticated: bool, trustworthy: bool = False, perms=()):
+    request = mock.Mock()
+    request.method = method
+    request.user.is_authenticated = is_authenticated
+    request.user.userprofile.is_trustworthy = trustworthy
+    request.user.has_perm.side_effect = lambda perm: perm in perms
+    return request
+
+
+class CanContributeExercisesTestCase(SimpleTestCase):
+    def setUp(self):
+        self.permission = CanContributeExercises()
+
+    def test_post_requires_add_permission(self):
+        request = build_request(
+            'POST',
+            is_authenticated=True,
+            perms={'exercises.change_exercise'},
+        )
+
+        self.assertFalse(self.permission.has_permission(request, None))
+
+    def test_patch_accepts_change_permission(self):
+        request = build_request(
+            'PATCH',
+            is_authenticated=True,
+            perms={'exercises.change_exercise'},
+        )
+
+        self.assertTrue(self.permission.has_permission(request, None))
+
+    def test_patch_rejects_user_without_change_permission(self):
+        request = build_request('PATCH', is_authenticated=True)
+
+        self.assertFalse(self.permission.has_permission(request, None))


### PR DESCRIPTION

**Repo:** wger-project/wger (⭐ 5970)
**Type:** bugfix
**Files changed:** 2
**Lines:** +54/-1

## What
This change fixes `CanContributeExercises` so `POST` still requires `exercises.add_exercise`, but `PUT` and `PATCH` now correctly require `exercises.change_exercise`. It also adds a focused regression test module that exercises the permission class directly and covers the create-vs-update distinction.

## Why
Before this patch, update requests were grouped with create requests, so a user with update rights but without create rights could not edit exercise data through the API. That is a real authorization bug because it blocks a valid permission combination and makes the permission class stricter than the underlying Django permission model.

## Testing
Verified syntax locally with `python -m compileall wger/exercises/api/permissions.py wger/exercises/tests/api/test_permissions.py`.
Attempted `python manage.py test wger.exercises.tests.api.test_permissions`, but the active interpreter does not have Django installed.
Attempted `UV_CACHE_DIR=/tmp/uv-cache uv run --group dev python manage.py test wger.exercises.tests.api.test_permissions`, but dependency resolution could not complete because network access is unavailable in the sandbox.

## Risk
Low / the change is narrowly scoped to request-method permission mapping and adds regression coverage for the exact permission split.
