### PR TITLE
Fix: Handle missing product_name in Open Food Facts import

### DIFF
--- a/wger/nutrition/extract_info/off.py
+++ b/wger/nutrition/extract_info/off.py
@@ -28,7 +28,6 @@ from wger.utils.constants import ODBL_LICENSE_ID
 
 
 OFF_REQUIRED_TOP_LEVEL = [
-    'product_name',
     'code',
     'nutriments',
 ]
@@ -116,7 +115,18 @@ def extract_info_from_off(product_data: dict, language: int) -> IngredientData:
         raise KeyError('Missing required nutrition key')
 
     # Basics
-    name = product_data.get('product_name', '')
+    # Try standard product_name or english fallback
+    name = product_data.get('product_name') or product_data.get('product_name_en')
+    # Fallback to ANY localized product name
+    if not name:
+        for key, value in product_data.items():
+            if key.startswith('product_name_') and value:
+                name = value
+                break
+    # If product name is still not found, throw error
+    if not name:
+        raise KeyError('Missing required product name')
+    
     common_name = product_data.get('generic_name', '')
 
     # If the energy is not available in kcal, convert from kJ

--- a/wger/nutrition/extract_info/off.py
+++ b/wger/nutrition/extract_info/off.py
@@ -126,7 +126,7 @@ def extract_info_from_off(product_data: dict, language: int) -> IngredientData:
     # If product name is still not found, throw error
     if not name:
         raise KeyError('Missing required product name')
-    
+
     common_name = product_data.get('generic_name', '')
 
     # If the energy is not available in kcal, convert from kJ

--- a/wger/nutrition/extract_info/off.py
+++ b/wger/nutrition/extract_info/off.py
@@ -115,15 +115,19 @@ def extract_info_from_off(product_data: dict, language: int) -> IngredientData:
         raise KeyError('Missing required nutrition key')
 
     # Basics
-    # Try standard product_name or english fallback
-    name = product_data.get('product_name') or product_data.get('product_name_en')
-    # Fallback to ANY localized product name
+    # Prefer the generic product_name, then the product's own language, then English,
+    # then any other localized name
+    lang = product_data.get('lang', '')
+    name = (
+        product_data.get('product_name')
+        or product_data.get(f'product_name_{lang}')
+        or product_data.get('product_name_en')
+    )
     if not name:
         for key, value in product_data.items():
             if key.startswith('product_name_') and value:
                 name = value
                 break
-    # If product name is still not found, throw error
     if not name:
         raise KeyError('Missing required product name')
 

--- a/wger/nutrition/tests/test_off.py
+++ b/wger/nutrition/tests/test_off.py
@@ -111,6 +111,53 @@ class ExtractInfoFromOffTestCase(SimpleTestCase):
 
         self.assertRaises(KeyError, extract_info_from_off, self.off_data1, 1)
 
+    def test_product_name_fallback_to_english(self):
+        """
+        If 'product_name' is missing, fall back to 'product_name_en'
+        """
+
+        del self.off_data1['product_name']
+        self.off_data1['product_name_en'] = 'Foo English'
+
+        result = extract_info_from_off(self.off_data1, 1)
+        self.assertEqual(result.name, 'Foo English')
+
+    def test_product_name_prefers_request_language(self):
+        """
+        If 'product_name' is missing, prefer the localized name matching 'lang'
+        over the English fallback
+        """
+
+        del self.off_data1['product_name']
+        self.off_data1['lang'] = 'de'
+        self.off_data1['product_name_de'] = 'Foo Deutsch'
+        self.off_data1['product_name_en'] = 'Foo English'
+        self.off_data1['product_name_fr'] = 'Foo Français'
+
+        result = extract_info_from_off(self.off_data1, 1)
+        self.assertEqual(result.name, 'Foo Deutsch')
+
+    def test_product_name_fallback_to_any_localized(self):
+        """
+        If neither 'product_name' nor 'product_name_en' is set, fall back to
+        any localized 'product_name_*' key
+        """
+
+        del self.off_data1['product_name']
+        self.off_data1['product_name_de'] = 'Foo Deutsch'
+
+        result = extract_info_from_off(self.off_data1, 1)
+        self.assertEqual(result.name, 'Foo Deutsch')
+
+    def test_no_product_name_at_all(self):
+        """
+        If no product name is present, raise KeyError
+        """
+
+        del self.off_data1['product_name']
+
+        self.assertRaises(KeyError, extract_info_from_off, self.off_data1, 1)
+
     def test_no_sugar_or_saturated_fat(self):
         """
         No sugar or saturated fat available


### PR DESCRIPTION
# Proposed Changes

This PR relaxes the strict `product_name` check during the Open Food Facts (OFF) import to prevent valid products from being rejected.

### Why?
Currently, `product_name` is listed in `OFF_REQUIRED_TOP_LEVEL`. However, Open Food Facts is sometimes inconsistent. For some products, the  `product_name` key is missing, and the API only returns localized versions like `product_name_en` or `product_name_de`.

### How I fixed it:
1. Removed `'product_name'` from `OFF_REQUIRED_TOP_LEVEL`.
2. Implemented a fallback logic in `extract_info_from_off`:
- First, it tries the generic `product_name` or `product_name_en`.
- If not found, it iterates through the keys to find any localized `product_name_*`.

To test you can use the barcode: `4260648131900`.
