### PR TITLE
feat: trigger Open Food Facts lookup on manual barcode text search

### DIFF
--- a/wger/nutrition/api/filtersets.py
+++ b/wger/nutrition/api/filtersets.py
@@ -70,7 +70,7 @@ class IngredientFilterSet(filters.FilterSet):
 
     def search_name_fulltext(self, queryset, name, value):
         """
-        Perform a fulltext search when a barcode is entered or postgres is available
+        Try a barcode lookup first, then perform a fulltext search when Postgres is available
         """
 
         # If a numeric value looks like a barcode (EAN-8, UPC-A, EAN-13, GTIN-14),

--- a/wger/nutrition/api/filtersets.py
+++ b/wger/nutrition/api/filtersets.py
@@ -70,8 +70,16 @@ class IngredientFilterSet(filters.FilterSet):
 
     def search_name_fulltext(self, queryset, name, value):
         """
-        Perform a fulltext search when postgres is available
+        Perform a fulltext search when a barcode is entered or postgres is available
         """
+
+        # If a numeric value looks like a barcode (EAN-8, UPC-A, EAN-13, GTIN-14),
+        # try an exact barcode lookup first.
+        if value.isdigit() and len(value) in (8, 12, 13, 14):
+            barcode_qs = self.search_barcode(queryset, 'code', value)
+
+            if barcode_qs.exists():
+                return barcode_qs
 
         if is_postgres_db():
             # Note: this uses the default value for pg_trgm.similarity_threshold (0.3) which

--- a/wger/nutrition/tests/test_search_api.py
+++ b/wger/nutrition/tests/test_search_api.py
@@ -22,6 +22,7 @@ from rest_framework import status
 # wger
 from wger.core.tests.api_base_test import ApiBaseTestCase
 from wger.core.tests.base_testcase import BaseTestCase
+from wger.nutrition.models import Ingredient
 
 
 class SearchIngredientApiTestCase(BaseTestCase, ApiBaseTestCase):
@@ -100,37 +101,56 @@ class SearchIngredientApiTestCase(BaseTestCase, ApiBaseTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 7)
 
-    @patch('wger.nutrition.models.Ingredient.fetch_ingredient_from_off')
-    def test_search_name_with_valid_barcode(self, mock_fetch):
+    @patch('wger.nutrition.api.filtersets.IngredientFilterSet.search_barcode')
+    def test_search_name_with_valid_barcode(self, mock_search_barcode):
         """
         Searching for an 8-14 digit number in the name field should trigger the OFF API lookup
         """
+        mock_search_barcode.return_value = Ingredient.objects.none()
         self.client.get(self.url + '?name__search=1300000000000')
-        mock_fetch.assert_called_once_with('1300000000000')
 
-    @patch('wger.nutrition.models.Ingredient.fetch_ingredient_from_off')
-    def test_search_name_with_text(self, mock_fetch):
+        args, kwargs = mock_search_barcode.call_args
+        self.assertEqual(args[1], 'code')
+        self.assertEqual(args[2], '1300000000000')
+
+    @patch('wger.nutrition.api.filtersets.IngredientFilterSet.search_barcode')
+    def test_search_name_with_text(self, mock_search_barcode):
         """
         Searching for a standard text string should fall back to full-text search
         """
         self.client.get(self.url + '?name__search=apples')
-        mock_fetch.assert_not_called()
+        mock_search_barcode.assert_not_called()
 
-    @patch('wger.nutrition.models.Ingredient.fetch_ingredient_from_off')
-    def test_search_name_with_short_number(self, mock_fetch):
+    @patch('wger.nutrition.api.filtersets.IngredientFilterSet.search_barcode')
+    def test_search_name_with_short_number(self, mock_search_barcode):
         """
         Searching for a short number (<8) should fall back to full-text search
         """
         self.client.get(self.url + '?name__search=7000000')
-        mock_fetch.assert_not_called()
+        mock_search_barcode.assert_not_called()
 
-    @patch('wger.nutrition.models.Ingredient.fetch_ingredient_from_off')
-    def test_search_name_with_long_number(self, mock_fetch):
+    @patch('wger.nutrition.api.filtersets.IngredientFilterSet.search_barcode')
+    def test_search_name_with_long_number(self, mock_search_barcode):
         """
         Searching for a long number (>14) should fall back to full-text search
         """
         self.client.get(self.url + '?name__search=150000000000000')
-        mock_fetch.assert_not_called()
+        mock_search_barcode.assert_not_called()
+
+    @patch('wger.nutrition.api.filtersets.IngredientFilterSet.search_barcode')
+    def test_search_name_returns_barcode(self, mock_search_barcode):
+        """
+        If search_barcode finds a match, it should return it
+        """
+        mock_search_barcode.return_value = Ingredient.objects.filter(pk=2)
+
+        response = self.client.get(self.url + '?name__search=1300000000000')
+        result1 = response.data['results'][0]
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(result1['name'], 'Ingredient, test, 2, organic, raw')
+        self.assertEqual(result1['id'], 2)
 
     def test_filter_nutriscore_exact(self):
         """

--- a/wger/nutrition/tests/test_search_api.py
+++ b/wger/nutrition/tests/test_search_api.py
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Workout Manager.  If not, see <http://www.gnu.org/licenses/>.
 
+# Standard Library
+from unittest.mock import patch
+
 # Third Party
 from rest_framework import status
 
@@ -96,6 +99,38 @@ class SearchIngredientApiTestCase(BaseTestCase, ApiBaseTestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 7)
+
+    @patch('wger.nutrition.models.Ingredient.fetch_ingredient_from_off')
+    def test_search_name_with_valid_barcode(self, mock_fetch):
+        """
+        Searching for an 8-14 digit number in the name field should trigger the OFF API lookup
+        """
+        self.client.get(self.url + '?name__search=1300000000000')
+        mock_fetch.assert_called_once_with('1300000000000')
+
+    @patch('wger.nutrition.models.Ingredient.fetch_ingredient_from_off')
+    def test_search_name_with_text(self, mock_fetch):
+        """
+        Searching for a standard text string should fall back to full-text search
+        """
+        self.client.get(self.url + '?name__search=apples')
+        mock_fetch.assert_not_called()
+
+    @patch('wger.nutrition.models.Ingredient.fetch_ingredient_from_off')
+    def test_search_name_with_short_number(self, mock_fetch):
+        """
+        Searching for a short number (<8) should fall back to full-text search
+        """
+        self.client.get(self.url + '?name__search=7000000')
+        mock_fetch.assert_not_called()
+
+    @patch('wger.nutrition.models.Ingredient.fetch_ingredient_from_off')
+    def test_search_name_with_long_number(self, mock_fetch):
+        """
+        Searching for a long number (>14) should fall back to full-text search
+        """
+        self.client.get(self.url + '?name__search=140000000000000')
+        mock_fetch.assert_not_called()
 
     def test_filter_nutriscore_exact(self):
         """

--- a/wger/nutrition/tests/test_search_api.py
+++ b/wger/nutrition/tests/test_search_api.py
@@ -129,7 +129,7 @@ class SearchIngredientApiTestCase(BaseTestCase, ApiBaseTestCase):
         """
         Searching for a long number (>14) should fall back to full-text search
         """
-        self.client.get(self.url + '?name__search=140000000000000')
+        self.client.get(self.url + '?name__search=150000000000000')
         mock_fetch.assert_not_called()
 
     def test_filter_nutriscore_exact(self):


### PR DESCRIPTION
# Proposed Changes

- Introduces a small improvement to the ingredient search, addressing my comment in #2340.
- Currently OFF lookups are only triggered when scanning a barcode via the camera. If a user manually enters a barcode into the search field, the system defaults to text search.
- This PR tries a barcode lookup first when the input looks like a barcode, and otherwise falls back to standard full-text search.

## Changes
- Updated `search_name_fulltext` in `nutrition/api/filtersets.py`. If the input is numeric and matches standard retail barcode lengths (8, 12, 13, 14 digits) the query is passed to `search_barcode`.
- Unit Testing: Added tests in `nutrition/tests/test_search_api.py`.

## Related Issue(s)
- Addresses my comment in #2340.
