### PR TITLE
fix: barcode fetch result was never returned

### DIFF
--- a/wger/nutrition/api/filtersets.py
+++ b/wger/nutrition/api/filtersets.py
@@ -61,12 +61,14 @@ class IngredientFilterSet(filters.FilterSet):
         if not value:
             return queryset
 
-        queryset = queryset.filter(code=value)
-        if queryset.count() == 0:
+        result = queryset.filter(code=value)
+        if not result.exists():
             logger.debug('barcode not found locally, trying to fetch ingredient from OFF')
-            Ingredient.fetch_ingredient_from_off(value)
+            ingredient = Ingredient.fetch_ingredient_from_off(value)
+            if ingredient is not None:
+                result = queryset.filter(pk=ingredient.pk)
 
-        return queryset
+        return result
 
     def search_name_fulltext(self, queryset, name, value):
         """

--- a/wger/nutrition/tests/test_search_api.py
+++ b/wger/nutrition/tests/test_search_api.py
@@ -13,12 +13,16 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Workout Manager.  If not, see <http://www.gnu.org/licenses/>.
 
+# Standard Library
+from unittest.mock import patch
+
 # Third Party
 from rest_framework import status
 
 # wger
 from wger.core.tests.api_base_test import ApiBaseTestCase
 from wger.core.tests.base_testcase import BaseTestCase
+from wger.nutrition.models import Ingredient
 
 
 class SearchIngredientApiTestCase(BaseTestCase, ApiBaseTestCase):
@@ -150,3 +154,40 @@ class SearchIngredientApiTestCase(BaseTestCase, ApiBaseTestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 6)
+
+    def test_barcode_found_locally(self):
+        """
+        A barcode already in the database is returned without calling OFF
+        """
+        response = self.client.get(self.url + '?code=1234567890987654321')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(response.data['results'][0]['id'], 1)
+
+    @patch('wger.nutrition.api.filtersets.Ingredient.fetch_ingredient_from_off')
+    def test_barcode_not_found_locally_off_succeeds(self, mock_fetch):
+        """
+        A barcode absent locally is fetched from OFF and the created ingredient is returned
+        """
+        mock_fetch.return_value = Ingredient.objects.get(pk=2)
+
+        response = self.client.get(self.url + '?code=0000000000000')
+
+        mock_fetch.assert_called_once_with('0000000000000')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(response.data['results'][0]['id'], 2)
+
+    @patch('wger.nutrition.api.filtersets.Ingredient.fetch_ingredient_from_off')
+    def test_barcode_not_found_locally_off_returns_none(self, mock_fetch):
+        """
+        A barcode unknown on OFF returns an empty result
+        """
+        mock_fetch.return_value = None
+
+        response = self.client.get(self.url + '?code=0000000000000')
+
+        mock_fetch.assert_called_once_with('0000000000000')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 0)


### PR DESCRIPTION
<!-- Thank you for contributing! If you want to suggest a new feature, please -->
<!-- discuss it first, either by opening a new issue, asking on an existing   -->
<!-- one, or on discord. -->

# Proposed Changes
### Before
When a client sent `GET /api/v2/ingredient/?code=<barcode>` for a barcode not yet in the local database, the method correctly called `Ingredient.fetch_ingredient_from_off(value)`, which fetched the product from Open Food Facts and saved it as a new Ingredient row. However, the return value of that call was discarded. The `queryset` variable, which was already bound to `queryset.filter(code=value)` with zero results, was returned unchanged. The API response therefore always contained an empty result set for any barcode that wasn't already local, even when the OFF fetch succeeded and the ingredient now existed in the database.

 ### After
The return value of `fetch_ingredient_from_off` is captured. If it is not `None` (i.e. the ingredient was successfully created), the result `queryset` is reassigned to `queryset.filter(pk=ingredient.pk)`, which resolves to the newly created row. The API response now correctly returns that ingredient. Filtering by `pk` rather than re-applying `code=value` also makes the fix robust against any barcode normalisation that OFF may apply before saving (e.g. stripping leading zeros), where a re-filter on the original code string could still return empty.

## Related Issue(s)

Tries to improve _ingredient search_ as per the general points described in #2340 


## Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code has been formatted to avoid unnecessary diffs (`ruff format && isort .`)
- [ ] If the feature is big enough or if there are manual steps needed (deployment
  changes etc.), write a small writeup in `CHANGELOG.md`
