### PR TITLE
fix: unknown language code is ignored instead of defaulted to english

### DIFF
--- a/wger/nutrition/api/filtersets.py
+++ b/wger/nutrition/api/filtersets.py
@@ -23,6 +23,7 @@ from django.contrib.postgres.search import TrigramSimilarity
 from django_filters import rest_framework as filters
 
 # wger
+from wger.core.models import Language
 from wger.nutrition.models import (
     Ingredient,
     LogItem,
@@ -98,7 +99,12 @@ class IngredientFilterSet(filters.FilterSet):
         Also accepts a comma-separated list of codes. Unknown codes are ignored
         and duplicates removed.
         """
-        languages = [load_language(l) for l in set(value.split(','))]
+        languages = []
+        for code in set(value.split(',')):
+            try:
+                languages.append(load_language(code, default_to_english=False))
+            except Language.DoesNotExist:
+                pass
         if languages:
             queryset = queryset.filter(language__in=languages)
 

--- a/wger/nutrition/tests/test_search_api.py
+++ b/wger/nutrition/tests/test_search_api.py
@@ -88,6 +88,15 @@ class SearchIngredientApiTestCase(BaseTestCase, ApiBaseTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 5)
 
+    def test_search_only_unknown_language_codes(self):
+        """
+        When all language codes are unknown the filter has no effect, not a silent English fallback
+        """
+        response = self.client.get(self.url + '?name__search=guest&language__code=kg')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 7)
+
     def test_search_all_languages(self):
         """
         Disable all language filters


### PR DESCRIPTION
<!-- Thank you for contributing! If you want to suggest a new feature, please -->
<!-- discuss it first, either by opening a new issue, asking on an existing   -->
<!-- one, or on discord. -->

# Proposed Changes
When filtering in the _Ingredient Search_ for languages that are unknown to the `wger` backend, the existing comment (`line 99`) suggests any unknown code is simply ignored, however I noticed it ended up being defaulted to _English_ instead (which would add _English_ to the list of languages for the results if it wasn't already in the list). 

If that is intended behavior, feel free to close without merging. 

If, however, it is not intended, I propose this slight rewrite to make sure unknown codes do NOT default to `en` and would simply not be considered a valid filter for search results. The existing test (`test_search_unknown_language_codes(self)`) did not catch this behavior because it had `en` as part of the set already, and therefore the `en` data items were included anyway.

## Related Issue(s)

<!-- If applicable, link to any related issues "Closes #123",    -->
<!-- "Closes wger-project/other-repo#123", "See also #123", etc. -->
Is a further attempt at improving the _ingredient search_ as mentioned in #2340 . 

I am trying to add some smaller fixes before trying myself in bigger search improvements, just to get a better understanding of the code base first. 

## Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code has been formatted to avoid unnecessary diffs (`ruff format && isort .`)
- [ ] If the feature is big enough or if there are manual steps needed (deployment
  changes etc.), write a small writeup in `CHANGELOG.md`
