### PR TITLE
feat: add kcal as a weight unit for cardio workout logging

### DIFF
--- a/wger/core/migrations/0023_add_kcal_weight_unit.py
+++ b/wger/core/migrations/0023_add_kcal_weight_unit.py
@@ -1,0 +1,16 @@
+from django.db import migrations
+
+
+def insert_kcal_unit(apps, schema_editor):
+    WeightUnit = apps.get_model('core', 'WeightUnit')
+    WeightUnit(name='kcal', pk=7).save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('core', '0022_move_email_verified_to_emailaddress'),
+    ]
+
+    operations = [
+        migrations.RunPython(insert_kcal_unit, reverse_code=migrations.RunPython.noop),
+    ]

--- a/wger/manager/consts.py
+++ b/wger/manager/consts.py
@@ -29,6 +29,7 @@ REP_UNIT_MILES = 5
 
 WEIGHT_UNIT_KG = 1
 WEIGHT_UNIT_LB = 2
+WEIGHT_UNIT_KCAL = 7
 
 # Unit type constants (matching RepetitionUnit.UNIT_TYPE_* choices)
 UNIT_TYPE_REPETITIONS = 'REPETITIONS'


### PR DESCRIPTION
## Summary

Adds `kcal` (kilocalorie) as a selectable weight unit for workout log entries, allowing users to record calories burned during cardio sessions alongside existing units like kg, lb, and km/h.

This implements the minimal backend change requested in #2019:

- Added `WEIGHT_UNIT_KCAL = 7` constant to `wger/manager/consts.py`
- Added data migration `0023_add_kcal_weight_unit.py` to seed the `kcal` WeightUnit row (pk=7)

## UI compatibility

The React frontend (`wger-project/react`) fetches weight units dynamically from the API via `getRoutineWeightUnits()` in `src/components/Routines/api/workoutUnits.ts`, which calls the `setting-weightunit` endpoint. No frontend changes are required — kcal will appear automatically in the unit selector once this migration runs.

## Out of scope (follow-up)

- Automatic calorie calculation from exercise type — as discussed in the issue, this is a separate, larger feature
- Flutter UI (tracked in wger-project/flutter)

Closes #2019

🤖 Generated with [Claude Code](https://claude.com/claude-code)