### PR TITLE
feat(nutrition): Refactor Ingredient categories to ManyToMany relationship (issue #984)

### DIFF
--- a/wger/core/tests/base_testcase.py
+++ b/wger/core/tests/base_testcase.py
@@ -122,6 +122,7 @@ class BaseTestCase:
         'test-exercises',
         'test-exercise-images',
         'test-exercise-videos',
+        'test-ingredient-categories',
         'test-ingredients',
         'test-nutrition-data',
         'test-nutrition-diary',

--- a/wger/nutrition/api/filtersets.py
+++ b/wger/nutrition/api/filtersets.py
@@ -143,6 +143,7 @@ class IngredientFilterSet(filters.FilterSet):
             'last_update': ['exact', 'gt', 'lt'],
             'last_imported': ['exact', 'gt', 'lt'],
             'language': ['exact', 'in'],
+            'category': ['exact', 'in'],
             'license': ['exact'],
             'license_author': ['exact'],
         }

--- a/wger/nutrition/api/serializers.py
+++ b/wger/nutrition/api/serializers.py
@@ -28,6 +28,7 @@ from rest_framework import serializers
 from wger.nutrition.models import (
     Image,
     Ingredient,
+    IngredientCategory,
     IngredientWeightUnit,
     LogItem,
     Meal,
@@ -86,6 +87,12 @@ class IngredientImageSerializer(serializers.ModelSerializer):
         )
 
 
+class IngredientCategorySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = IngredientCategory
+        fields = ('id', 'name')
+
+
 class IngredientSerializer(serializers.ModelSerializer):
     """
     Ingredient serializer
@@ -120,6 +127,7 @@ class IngredientSerializer(serializers.ModelSerializer):
             'is_vegetarian',
             'weight_units',
             'nutriscore',
+            'category',
             'license',
             'license_title',
             'license_object_url',
@@ -136,6 +144,7 @@ class IngredientInfoSerializer(serializers.ModelSerializer):
     """
 
     weight_units = IngredientWeightUnitSerializer(source='ingredientweightunit_set', many=True)
+    category = IngredientCategorySerializer(many=True, read_only=True)
     image = IngredientImageSerializer(read_only=True)
     thumbnails = serializers.SerializerMethodField()
 
@@ -167,6 +176,7 @@ class IngredientInfoSerializer(serializers.ModelSerializer):
             'is_vegetarian',
             'nutriscore',
             'weight_units',
+            'category',
             'language',
             'license',
             'license_title',

--- a/wger/nutrition/api/views.py
+++ b/wger/nutrition/api/views.py
@@ -157,7 +157,7 @@ class IngredientInfoViewSet(IngredientViewSet):
         # See IngredientViewSet.queryset for the rationale behind .order_by().
         return (
             Ingredient.objects.select_related('language', 'license', 'image')
-            .prefetch_related('ingredientweightunit_set')
+            .prefetch_related('ingredientweightunit_set', 'category')
             .order_by()
         )
 
@@ -186,7 +186,7 @@ class IngredientSyncViewSet(viewsets.ReadOnlyModelViewSet):
             'language',
             'license',
             'image',
-        ).prefetch_related('ingredientweightunit_set')
+        ).prefetch_related('ingredientweightunit_set', 'category')
 
 
 class ImageViewSet(viewsets.ReadOnlyModelViewSet):

--- a/wger/nutrition/api/views.py
+++ b/wger/nutrition/api/views.py
@@ -50,6 +50,7 @@ from wger.nutrition.forms import UnitChooserForm
 from wger.nutrition.models import (
     Image,
     Ingredient,
+    IngredientCategory,
     IngredientWeightUnit,
     LogItem,
     Meal,
@@ -301,6 +302,10 @@ class NutritionPlanInfoViewSet(NutritionPlanViewSet):
                             Prefetch(
                                 'ingredient__ingredientweightunit_set',
                                 queryset=IngredientWeightUnit.objects.select_related('ingredient'),
+                            ),
+                            Prefetch(
+                                'ingredient__category',
+                                queryset=IngredientCategory.objects.all(),
                             ),
                         ),
                     ),

--- a/wger/nutrition/dataclasses.py
+++ b/wger/nutrition/dataclasses.py
@@ -16,9 +16,12 @@
 from dataclasses import (
     asdict,
     dataclass,
-    field
+    field,
 )
-from typing import List, Optional
+from typing import (
+    List,
+    Optional,
+)
 
 # wger
 from wger.nutrition.helpers import (

--- a/wger/nutrition/dataclasses.py
+++ b/wger/nutrition/dataclasses.py
@@ -114,6 +114,7 @@ class IngredientData:
         data.pop('serving_size_gram', None)
         data.pop('serving_size_unit', None)
         data.pop('serving_size_amount', None)
+        data.pop('categories', None)
         return data
 
     def clean_name(self):

--- a/wger/nutrition/dataclasses.py
+++ b/wger/nutrition/dataclasses.py
@@ -16,8 +16,9 @@
 from dataclasses import (
     asdict,
     dataclass,
+    field
 )
-from typing import Optional
+from typing import List, Optional
 
 # wger
 from wger.nutrition.helpers import (
@@ -63,6 +64,7 @@ class IngredientData:
     serving_size_unit: Optional[str] = None
     serving_size_amount: Optional[float] = None
     nutriscore: Optional[str] = None
+    categories: List[str] = field(default_factory=list)
 
     def sanity_checks(self):
         if not self.name:

--- a/wger/nutrition/extract_info/off.py
+++ b/wger/nutrition/extract_info/off.py
@@ -187,6 +187,18 @@ def extract_info_from_off(product_data: dict, language: int) -> IngredientData:
     if nutriscore_value not in ('a', 'b', 'c', 'd', 'e'):
         nutriscore_value = None
 
+    raw_categories_tags = product_data.get('categories_tags', [])
+    if not raw_categories_tags and 'categories' in product_data:
+        raw_categories_tags = [
+            c.strip() for c in product_data['categories'].split(',') if c.strip()
+        ]
+    cleaned_categories = []
+    for tag in raw_categories_tags:
+        # Strip prefixes like 'en:', 'fr:'
+        cleaned_tag = tag.split(':')[1].replace('-', ' ').title()
+        if cleaned_tag:
+            cleaned_categories.append(cleaned_tag)
+
     # License and author info
     source_name = Source.OPEN_FOOD_FACTS.value
     source_url = f'https://world.openfoodfacts.org/api/v2/product/{code}.json'
@@ -220,6 +232,7 @@ def extract_info_from_off(product_data: dict, language: int) -> IngredientData:
         serving_size_unit=serving_size_unit,
         serving_size_amount=serving_size_amount,
         nutriscore=nutriscore_value,
+        categories=cleaned_categories,
     )
     ingredient_data.sanity_checks()
     return ingredient_data

--- a/wger/nutrition/extract_info/off.py
+++ b/wger/nutrition/extract_info/off.py
@@ -194,8 +194,14 @@ def extract_info_from_off(product_data: dict, language: int) -> IngredientData:
         ]
     cleaned_categories = []
     for tag in raw_categories_tags:
-        # Strip prefixes like 'en:', 'fr:'
-        cleaned_tag = tag.split(':')[1].replace('-', ' ').title()
+        if not tag:
+            continue
+        if ':' in tag:
+            # Strip prefixes like 'en:', 'fr:'
+            parts = tag.split(':', 1)
+            cleaned_tag = parts[1].replace('-', ' ').title()
+        else:
+            cleaned_tag = tag.replace('-', ' ').title()
         if cleaned_tag:
             cleaned_categories.append(cleaned_tag)
 

--- a/wger/nutrition/fixtures/test-ingredient-categories.json
+++ b/wger/nutrition/fixtures/test-ingredient-categories.json
@@ -1,0 +1,44 @@
+[
+  {
+    "model": "nutrition.ingredientcategory",
+    "pk": 1,
+    "fields": {
+      "name": "Snacks"
+    }
+  },
+  {
+    "model": "nutrition.ingredientcategory",
+    "pk": 2,
+    "fields": {
+      "name": "Sweet Snacks"
+    }
+  },
+  {
+    "model": "nutrition.ingredientcategory",
+    "pk": 3,
+    "fields": {
+      "name": "Cocoa And Its Products"
+    }
+  },
+  {
+    "model": "nutrition.ingredientcategory",
+    "pk": 4,
+    "fields": {
+      "name": "Chocolates"
+    }
+  },
+  {
+    "model": "nutrition.ingredientcategory",
+    "pk": 5,
+    "fields": {
+      "name": "Dark Chocolates"
+    }
+  },
+  {
+    "model": "nutrition.ingredientcategory",
+    "pk": 6,
+    "fields": {
+      "name": "Dark Chocolate Bar With More Than 70 Cocoa"
+    }
+  }
+]

--- a/wger/nutrition/fixtures/test-ingredients.json
+++ b/wger/nutrition/fixtures/test-ingredients.json
@@ -26,7 +26,10 @@
       "brand": "the food brand",
       "is_vegan": false,
       "is_vegetarian": true,
-      "nutriscore": "b"
+      "nutriscore": "b",
+      "category": [
+        1, 2, 3, 4, 5, 6
+      ]
     }
   },
   {
@@ -56,7 +59,10 @@
       "brand": "the food brand",
       "is_vegan": true,
       "is_vegetarian": true,
-      "nutriscore": "a"
+      "nutriscore": "a",
+      "category": [
+        1, 2, 3, 4, 5, 6
+      ]
     }
   },
   {
@@ -86,7 +92,10 @@
       "brand": "the food brand",
       "is_vegan": false,
       "is_vegetarian": false,
-      "nutriscore": "c"
+      "nutriscore": "c",
+      "category": [
+        1, 2, 3, 4, 5, 6
+      ]
     }
   },
   {
@@ -116,7 +125,10 @@
       "brand": "the food brand",
       "is_vegan": true,
       "is_vegetarian": true,
-      "nutriscore": "e"
+      "nutriscore": "e",
+      "category": [
+        1, 2, 3, 4, 5, 6
+      ]
     }
   },
   {
@@ -146,7 +158,10 @@
       "brand": "the food brand",
       "is_vegan": null,
       "is_vegetarian": true,
-      "nutriscore": "b"
+      "nutriscore": "b",
+      "category": [
+        1, 2, 3, 4, 5, 6
+      ]
     }
   },
   {
@@ -176,7 +191,10 @@
       "brand": "the food brand",
       "is_vegan": false,
       "is_vegetarian": true,
-      "nutriscore": "a"
+      "nutriscore": "a",
+      "category": [
+        1, 2, 3, 4, 5, 6
+      ]
     }
   },
   {
@@ -206,7 +224,10 @@
       "brand": "the food brand",
       "is_vegan": null,
       "is_vegetarian": null,
-      "nutriscore": null
+      "nutriscore": null,
+      "category": [
+        1, 2, 3, 4, 5, 6
+      ]
     }
   },
   {
@@ -236,7 +257,10 @@
       "brand": "the food brand",
       "is_vegan": true,
       "is_vegetarian": true,
-      "nutriscore": "b"
+      "nutriscore": "b",
+      "category": [
+        1, 2, 3, 4, 5, 6
+      ]
     }
   },
   {
@@ -266,7 +290,10 @@
       "brand": "the food brand",
       "is_vegan": false,
       "is_vegetarian": false,
-      "nutriscore": "d"
+      "nutriscore": "d",
+      "category": [
+        1, 2, 3, 4, 5, 6
+      ]
     }
   },
   {
@@ -296,7 +323,10 @@
       "brand": "the food brand",
       "is_vegan": true,
       "is_vegetarian": true,
-      "nutriscore": "a"
+      "nutriscore": "a",
+      "category": [
+        1, 2, 3, 4, 5, 6
+      ]
     }
   },
   {
@@ -326,7 +356,10 @@
       "brand": "the food brand",
       "is_vegan": false,
       "is_vegetarian": true,
-      "nutriscore": "c"
+      "nutriscore": "c",
+      "category": [
+        1, 2, 3, 4, 5, 6
+      ]
     }
   },
   {
@@ -356,7 +389,10 @@
       "brand": "the food brand",
       "is_vegan": null,
       "is_vegetarian": false,
-      "nutriscore": "d"
+      "nutriscore": "d",
+      "category": [
+        1, 2, 3, 4, 5, 6
+      ]
     }
   },
   {
@@ -386,7 +422,10 @@
       "brand": "the food brand",
       "is_vegan": true,
       "is_vegetarian": true,
-      "nutriscore": "b"
+      "nutriscore": "b",
+      "category": [
+        1, 2, 3, 4, 5, 6
+      ]
     }
   },
   {
@@ -416,7 +455,10 @@
       "brand": "the food brand",
       "is_vegan": false,
       "is_vegetarian": true,
-      "nutriscore": "c"
+      "nutriscore": "c",
+      "category": [
+        1, 2, 3, 4, 5, 6
+      ]
     }
   },
   {

--- a/wger/nutrition/migrations/0038_ingredient_multi_categories.py
+++ b/wger/nutrition/migrations/0038_ingredient_multi_categories.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("nutrition", "0037_powersync_synced_ingredient_tables"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="ingredient",
+            name="category",
+        ),
+        migrations.AddField(
+            model_name="ingredient",
+            name="category",
+            field=models.ManyToManyField(
+                blank=True,
+                related_name="ingredients",
+                to="nutrition.ingredientcategory",
+                verbose_name="Category",
+            ),
+        ),
+    ]

--- a/wger/nutrition/migrations/0038_ingredient_multi_categories.py
+++ b/wger/nutrition/migrations/0038_ingredient_multi_categories.py
@@ -1,24 +1,33 @@
 from django.db import migrations, models
+from django.db.migrations.state import StateApps
+
+
+def migrate_foreign_key_to_m2m(apps: StateApps, schema_editor):
+    Ingredient = apps.get_model('nutrition', 'Ingredient')
+    for ingre in Ingredient.objects.exclude(category_id__isnull=True):
+        ingre.categories.add(ingre.category)
 
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("nutrition", "0037_powersync_synced_ingredient_tables"),
+        ('nutrition', '0037_powersync_synced_ingredient_tables'),
     ]
 
     operations = [
-        migrations.RemoveField(
-            model_name="ingredient",
-            name="category",
-        ),
         migrations.AddField(
-            model_name="ingredient",
-            name="category",
+            model_name='ingredient',
+            name='categories',
             field=models.ManyToManyField(
                 blank=True,
-                related_name="ingredients",
-                to="nutrition.ingredientcategory",
-                verbose_name="Category",
+                related_name='ingredients',
+                to='nutrition.ingredientcategory',
+                verbose_name='Categories',
             ),
         ),
+        migrations.RunPython(migrate_foreign_key_to_m2m, reverse_code=migrations.RunPython.noop),
+        migrations.RemoveField(
+            model_name='ingredient',
+            name='category',
+        ),
+        migrations.RenameField(model_name='ingredient', old_name='categories', new_name='category'),
     ]

--- a/wger/nutrition/models/ingredient.py
+++ b/wger/nutrition/models/ingredient.py
@@ -602,12 +602,17 @@ class Ingredient(AbstractLicenseModel, models.Model):
         ingredient_data = cls._extract_off_ingredient_data(result, language.pk)
         if not ingredient_data:
             return None
-
         if not ingredient_data.name:
             return None
+        extracted_categories = ingredient_data.categories
 
         ingredient = cls(**ingredient_data.dict())
         ingredient.save()
+
+        for category_name in extracted_categories:
+            category_obj, created = IngredientCategory.objects.get_or_create(name=category_name)
+            ingredient.category.add(category_obj)
+
         ingredient.update_or_create_serving_unit_from_off(ingredient_data)
         logger.info(f'Ingredient found and saved to local database: {ingredient.uuid}')
         return ingredient

--- a/wger/nutrition/models/ingredient.py
+++ b/wger/nutrition/models/ingredient.py
@@ -274,11 +274,10 @@ class Ingredient(AbstractLicenseModel, models.Model):
         blank=True,
     )
 
-    category = models.ForeignKey(
+    category = models.ManyToManyField(
         IngredientCategory,
         verbose_name='Category',
-        on_delete=models.CASCADE,
-        null=True,
+        related_name='ingredients',
         blank=True,
     )
 

--- a/wger/nutrition/models/ingredient.py
+++ b/wger/nutrition/models/ingredient.py
@@ -19,6 +19,7 @@ import logging
 import uuid as uuid
 from decimal import Decimal
 from json import JSONDecodeError
+from typing import List
 
 # Django
 from django.conf import settings
@@ -28,7 +29,10 @@ from django.core.validators import (
     MinLengthValidator,
     MinValueValidator,
 )
-from django.db import models
+from django.db import (
+    models,
+    transaction,
+)
 from django.http import HttpRequest
 from django.urls import reverse
 from django.utils import translation
@@ -276,7 +280,7 @@ class Ingredient(AbstractLicenseModel, models.Model):
 
     category = models.ManyToManyField(
         IngredientCategory,
-        verbose_name='Category',
+        verbose_name='Categories',
         related_name='ingredients',
         blank=True,
     )
@@ -584,6 +588,31 @@ class Ingredient(AbstractLicenseModel, models.Model):
         return self.update_or_create_serving_unit_from_off(ingredient_data)
 
     @classmethod
+    def _assign_categories(cls, ingredient: 'Ingredient', category_names: List[str]) -> None:
+        """Helper method to assign categories to an ingredient."""
+        normalized_names = [
+            name.strip().capitalize() for name in category_names if name and name.strip()
+        ]
+
+        if not normalized_names:
+            ingredient.category.clear()
+            return
+
+        # Get existing categories
+        existing = IngredientCategory.objects.filter(name__in=normalized_names).values_list(
+            'name', flat=True
+        )
+        missing = [n for n in normalized_names if n not in existing]
+        if missing:
+            IngredientCategory.objects.bulk_create(
+                [IngredientCategory(name=name) for name in missing], ignore_conflicts=True
+            )
+
+        # get newly created categories
+        all_qs = IngredientCategory.objects.filter(name__in=normalized_names)
+        ingredient.category.set(all_qs)
+
+    @classmethod
     def fetch_ingredient_from_off(cls, code: str):
         """
         Searches OFF by barcode and creates a local ingredient from the result
@@ -600,19 +629,16 @@ class Ingredient(AbstractLicenseModel, models.Model):
             return None
 
         ingredient_data = cls._extract_off_ingredient_data(result, language.pk)
-        if not ingredient_data:
-            return None
-        if not ingredient_data.name:
+        if not ingredient_data or not ingredient_data.name:
             return None
         extracted_categories = ingredient_data.categories
 
-        ingredient = cls(**ingredient_data.dict())
-        ingredient.save()
+        with transaction.atomic():
+            ingredient = cls(**ingredient_data.dict())
+            ingredient.save()
 
-        for category_name in extracted_categories:
-            category_obj, created = IngredientCategory.objects.get_or_create(name=category_name)
-            ingredient.category.add(category_obj)
+            cls._assign_categories(ingredient, extracted_categories)
+            ingredient.update_or_create_serving_unit_from_off(ingredient_data)
 
-        ingredient.update_or_create_serving_unit_from_off(ingredient_data)
-        logger.info(f'Ingredient found and saved to local database: {ingredient.uuid}')
+            logger.info(f'Ingredient found and saved to local database: {ingredient.uuid}')
         return ingredient

--- a/wger/nutrition/tests/test_ingredient.py
+++ b/wger/nutrition/tests/test_ingredient.py
@@ -481,6 +481,11 @@ class IngredientModelTestCase(WgerTestCase):
                 'en:vegan',
                 'en:vegetarian',
             ],
+            'categories_tags': [
+                'en:snacks',
+                'en:sweet-snacks',
+                'en:chocolates'
+            ],
             'nutriments': {
                 'energy-kcal_100g': 600,
                 'proteins_100g': 10,
@@ -517,6 +522,11 @@ class IngredientModelTestCase(WgerTestCase):
         self.assertEqual(ingredient.license_author, 'open food facts, MrX')
         self.assertTrue(ingredient.is_vegan)
         self.assertTrue(ingredient.is_vegetarian)
+
+        # categories
+        assigned_categories = ingredient.category.all()
+        self.assertEqual(assigned_categories.count(), 3)
+        self.assertIn('Sweet snacks', [cat.name for cat in assigned_categories])
 
     @patch('openfoodfacts.api.ProductResource.get')
     def test_fetch_from_off_updates_existing_serving_unit(self, mock_api: MagicMock):
@@ -924,3 +934,18 @@ class IngredientSyncViewSetTestCase(WgerTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         entry = next(i for i in response.data['results'] if i['id'] == 1)
         self.assertIsNone(entry['thumbnails'])
+
+    def test_api_returns_nested_categories_list(self):
+        """Verify API GET operations return complete nested arrays for category records."""
+
+        response = self.client.get(reverse('api-ingredientinfo-list'))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        results = response.data.get('results', [])
+        target_ingredient = next((item for item in results if item['id'] == 2), None)
+        self.assertIsNotNone(target_ingredient, "Fixture ingredient PK=2 missing from API response")
+
+        self.assertIn('category', target_ingredient)
+        self.assertEqual(len(target_ingredient['category']), 6)
+        first_category = target_ingredient['category'][0]
+        self.assertIn('name', first_category)

--- a/wger/nutrition/tests/test_off.py
+++ b/wger/nutrition/tests/test_off.py
@@ -55,6 +55,11 @@ class ExtractInfoFromOffTestCase(SimpleTestCase):
                 'other_stuff': 'is ignored',
             },
             'serving_size': '',
+            'categories_tags': [
+                'en:snacks',
+                'en:cocoa-and-its-products',
+                'en:dark-chocolates',
+            ],
         }
 
     def test_regular_response(self):
@@ -86,6 +91,11 @@ class ExtractInfoFromOffTestCase(SimpleTestCase):
             is_vegan=True,
             is_vegetarian=True,
             nutriscore='c',
+            categories=[
+                'Snacks',
+                'Cocoa And Its Products',
+                'Dark Chocolates',
+            ],
         )
 
         self.assertEqual(result, data)
@@ -309,3 +319,14 @@ class ExtractInfoFromOffTestCase(SimpleTestCase):
         self.assertIsNone(result.serving_size_gram)
         self.assertEqual(result.serving_size_unit, 'ml')
         self.assertEqual(result.serving_size_amount, 200)
+
+    def test_categories_extraction_parsing(self):
+        """Ensure categories lists are parsed, cleaned, and properly assigned into intermediate dataclass"""
+        self.off_data1['categories_tags'] = [
+            'en:snacks',
+            'en:sweet-snacks-cocoa',
+        ]
+        result = extract_info_from_off(self.off_data1, 1)
+
+        self.assertEqual(result.categories, ['Snacks', 'Sweet Snacks Cocoa'])
+        self.assertIn('Sweet Snacks Cocoa', result.categories)


### PR DESCRIPTION
<!-- Thank you for contributing! If you want to suggest a new feature, please -->
<!-- discuss it first, either by opening a new issue, asking on an existing   -->
<!-- one, or on discord. -->


#### PR Description:

This PR refactors the `Ingredient` model to support multiple categories per ingredient, moving away from a restricted 1:N relationship. This aligns with Open Food Facts data structures.

| # | File Path | Change Summary |
| --- | --- | --- |
| 1 | `wger/nutrition/api/serializers.py` | Registered `IngredientCategorySerializer` and added to `IngredientInfoSerializer`. |
| 2 | `wger/nutrition/api/views.py` | Added `category` to `prefetch_related` to optimize database queries. |
| 3 | `wger/nutrition/dataclasses.py` | Added `categories` to data cleaning lifecycle. |
| 4 | `wger/nutrition/extract_info/off.py` | Implemented parsing logic for nested category tags. |
| 5 | `wger/nutrition/migrations/0038...` | Created data migration for safe transition from FK to M2M. |
| 6 | `wger/nutrition/models/ingredient.py` | Added `_assign_categories` helper and atomic saving logic. |

## Related Issue(s)

<!-- If applicable, link to any related issues "Closes #123",    -->
<!-- "Closes wger-project/other-repo#123", "See also #123", etc. -->
- Closes #984

## Please check that the PR fulfills these requirements

- [x] Code has been formatted to avoid unnecessary diffs (`ruff format && isort .`)
- [ ] If the feature is big enough or if there are manual steps needed (deployment
  changes etc.), write a small writeup in `CHANGELOG.md`

EDIT:
- [x] Tests for the changes have been added (for bug fixes / features)

