### PR TITLE
Require POST for password reset and user (de)activation

### DIFF
--- a/wger/core/templates/confirm.html
+++ b/wger/core/templates/confirm.html
@@ -1,0 +1,7 @@
+{% load i18n crispy_forms_tags %}
+
+<h4>{{ title }}</h4>
+{% if confirm_message %}
+    <p>{{ confirm_message }}</p>
+{% endif %}
+{% crispy form %}

--- a/wger/core/templates/user/overview.html
+++ b/wger/core/templates/user/overview.html
@@ -241,13 +241,9 @@
                 {% url 'core:user:activate' current_user.pk as url %}
                 {% modal_link url=url text=text css_class='dropdown-item' %}
             {% endif %}
-        <a
-            data-url="{% url 'gym:gym:reset-user-password' current_user.pk %}"
-            data-bs-toggle="modal"
-            data-bs-target="#confirmation-modal"
-            class="dropdown-item">
-            {% translate "Reset user password" %}
-        </a>
+        {% translate 'Reset user password' as text %}
+        {% url 'gym:gym:reset-user-password' current_user.pk as url %}
+        {% modal_link url=url text=text css_class='dropdown-item' %}
         {% if perms.gym.manage_gym or perms.gym.manage_gyms %}
         {% if current_user.userprofile.gym %}
             {% translate 'Roles' as text %}
@@ -261,38 +257,6 @@
         {% modal_link url=url text=text css_class='dropdown-item' %}
     </div>
 </div>
-
-<div id="confirmation-modal" class="modal fade" tabindex="-1" role="dialog">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h4 class="modal-title">{% translate 'Password reset confirmation' %}</h4>
-                <button type="button" class="close" data-bs-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-            </div>
-            <div class="modal-body">
-                <p>{% translate 'Do you really want to change this user&#39;s password?' %}</p>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-danger" data-bs-dismiss="modal">{% translate 'No' %}</button>
-                <button type="button" class="btn btn-success">{% translate 'Yes' %}</button>
-            </div>
-        </div>
-    </div>
-</div>
-
-<script>
-    $(document).ready(function() {
-        $('#confirmation-modal').on('show.bs.modal', function (event) {
-            var button = $(event.relatedTarget);
-            var url = button.data('url');
-            var modal = $(this);
-
-            modal.find('button.btn-success').click(function() {
-                window.location.href = url;
-            });
-        });
-    });
-</script>
 
 {% endif %}
 <h4>{% translate "Details" %}</h4>

--- a/wger/core/tests/test_user.py
+++ b/wger/core/tests/test_user.py
@@ -67,7 +67,7 @@ class StatusUserTestCase(WgerTestCase):
         user.save()
         self.assertFalse(user.is_active)
 
-        response = self.client.get(reverse('core:user:activate', kwargs={'pk': user.pk}))
+        response = self.client.post(reverse('core:user:activate', kwargs={'pk': user.pk}))
         user = User.objects.get(pk=2)
 
         self.assertIn(response.status_code, (302, 403))
@@ -109,7 +109,7 @@ class StatusUserTestCase(WgerTestCase):
         user.save()
         self.assertTrue(user.is_active)
 
-        response = self.client.get(reverse('core:user:deactivate', kwargs={'pk': user.pk}))
+        response = self.client.post(reverse('core:user:deactivate', kwargs={'pk': user.pk}))
         user = User.objects.get(pk=2)
 
         self.assertIn(response.status_code, (302, 403))
@@ -141,6 +141,38 @@ class StatusUserTestCase(WgerTestCase):
         Tests deactivating a user a logged out user
         """
         self.deactivate(fail=True)
+
+    def test_activate_get_does_not_mutate(self):
+        """
+        Regression test: GET must only render a confirmation form, since
+        Django's CSRF protection does not apply to GET requests. The state
+        change must require POST.
+        """
+        user = User.objects.get(pk=2)
+        user.is_active = False
+        user.save()
+
+        self.user_login(self.user_success[0])
+        response = self.client.get(reverse('core:user:activate', kwargs={'pk': user.pk}))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(User.objects.get(pk=2).is_active)
+
+    def test_deactivate_get_does_not_mutate(self):
+        """
+        Regression test: GET must only render a confirmation form, since
+        Django's CSRF protection does not apply to GET requests. The state
+        change must require POST.
+        """
+        user = User.objects.get(pk=2)
+        user.is_active = True
+        user.save()
+
+        self.user_login(self.user_success[0])
+        response = self.client.get(reverse('core:user:deactivate', kwargs={'pk': user.pk}))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(User.objects.get(pk=2).is_active)
 
 
 class TrainerCannotDeactivatePrivilegedUsersTestCase(WgerTestCase):
@@ -197,7 +229,7 @@ class TrainerCannotDeactivatePrivilegedUsersTestCase(WgerTestCase):
         member of their own gym) must keep working.
         """
         self.user_login(self.TRAINER)
-        response = self.client.get(
+        response = self.client.post(
             reverse('core:user:deactivate', kwargs={'pk': self.REGULAR_MEMBER_PK})
         )
         self.assertEqual(response.status_code, 302)

--- a/wger/core/views/user.py
+++ b/wger/core/views/user.py
@@ -336,7 +336,7 @@ class UserActivationConfirmMixin:
     (e.g. POST), not GET.
     """
 
-    confirm_message = ''
+    confirm_title = ''
     success_message = ''
     new_is_active = None
 
@@ -347,14 +347,14 @@ class UserActivationConfirmMixin:
         form.helper.form_method = 'post'
         form.helper.form_action = request.path
         form.helper.layout = Layout(
-            ButtonHolder(Submit('submit', self.confirm_message, css_class='btn-warning btn-block'))
+            ButtonHolder(Submit('submit', self.confirm_title, css_class='btn-warning btn-block'))
         )
         return render(
             request,
-            'delete.html',
+            'confirm.html',
             {
-                'title': self.confirm_message,
-                'delete_message': str(edit_user),
+                'title': self.confirm_title,
+                'confirm_message': str(edit_user),
                 'form': form,
             },
         )
@@ -379,7 +379,7 @@ class UserDeactivateView(
 
     model = User
     permission_required = ('gym.manage_gym', 'gym.manage_gyms', 'gym.gym_trainer')
-    confirm_message = gettext_lazy('Deactivate this user?')
+    confirm_title = gettext_lazy('Deactivate this user?')
     success_message = gettext_lazy('The user was successfully deactivated')
     new_is_active = False
 
@@ -427,7 +427,7 @@ class UserActivateView(
 
     model = User
     permission_required = ('gym.manage_gym', 'gym.manage_gyms', 'gym.gym_trainer')
-    confirm_message = gettext_lazy('Activate this user?')
+    confirm_title = gettext_lazy('Activate this user?')
     success_message = gettext_lazy('The user was successfully activated')
     new_is_active = True
 

--- a/wger/core/views/user.py
+++ b/wger/core/views/user.py
@@ -20,6 +20,7 @@ import re
 from urllib.parse import quote
 
 # Django
+from django import forms
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import (
@@ -58,11 +59,11 @@ from django.utils.translation import (
     gettext as _,
     gettext_lazy,
 )
+from django.views import generic
 from django.views.decorators.http import require_POST
 from django.views.generic import (
     DetailView,
     ListView,
-    RedirectView,
     UpdateView,
 )
 
@@ -327,18 +328,60 @@ def preferences(request):
     return render(request, 'user/preferences.html', context)
 
 
+class UserActivationConfirmMixin:
+    """
+    GET renders a confirmation form; only POST applies the activation state
+    change. (De)activating a user is a state change and must go through
+    Django's CSRF protection, which only applies to unsafe HTTP methods
+    (e.g. POST), not GET.
+    """
+
+    confirm_message = ''
+    success_message = ''
+    new_is_active = None
+
+    def get(self, request, pk):
+        edit_user = get_object_or_404(User, pk=pk)
+        form = forms.Form()
+        form.helper = FormHelper()
+        form.helper.form_method = 'post'
+        form.helper.form_action = request.path
+        form.helper.layout = Layout(
+            ButtonHolder(Submit('submit', self.confirm_message, css_class='btn-warning btn-block'))
+        )
+        return render(
+            request,
+            'delete.html',
+            {
+                'title': self.confirm_message,
+                'delete_message': str(edit_user),
+                'form': form,
+            },
+        )
+
+    def post(self, request, pk):
+        edit_user = get_object_or_404(User, pk=pk)
+        edit_user.is_active = self.new_is_active
+        edit_user.save()
+        messages.success(request, self.success_message)
+        return HttpResponseRedirect(reverse('core:user:overview', kwargs={'pk': pk}))
+
+
 class UserDeactivateView(
     LoginRequiredMixin,
     WgerMultiplePermissionRequiredMixin,
-    RedirectView,
+    UserActivationConfirmMixin,
+    generic.View,
 ):
     """
     Deactivates a user
     """
 
-    permanent = False
     model = User
     permission_required = ('gym.manage_gym', 'gym.manage_gyms', 'gym.gym_trainer')
+    confirm_message = gettext_lazy('Deactivate this user?')
+    success_message = gettext_lazy('The user was successfully deactivated')
+    new_is_active = False
 
     def dispatch(self, request, *args, **kwargs):
         """
@@ -371,26 +414,22 @@ class UserDeactivateView(
 
         return super(UserDeactivateView, self).dispatch(request, *args, **kwargs)
 
-    def get_redirect_url(self, pk):
-        edit_user = get_object_or_404(User, pk=pk)
-        edit_user.is_active = False
-        edit_user.save()
-        messages.success(self.request, _('The user was successfully deactivated'))
-        return reverse('core:user:overview', kwargs=({'pk': pk}))
-
 
 class UserActivateView(
     LoginRequiredMixin,
     WgerMultiplePermissionRequiredMixin,
-    RedirectView,
+    UserActivationConfirmMixin,
+    generic.View,
 ):
     """
     Activates a previously deactivated user
     """
 
-    permanent = False
     model = User
     permission_required = ('gym.manage_gym', 'gym.manage_gyms', 'gym.gym_trainer')
+    confirm_message = gettext_lazy('Activate this user?')
+    success_message = gettext_lazy('The user was successfully activated')
+    new_is_active = True
 
     def dispatch(self, request, *args, **kwargs):
         """
@@ -422,13 +461,6 @@ class UserActivateView(
             return HttpResponseForbidden()
 
         return super(UserActivateView, self).dispatch(request, *args, **kwargs)
-
-    def get_redirect_url(self, pk):
-        edit_user = get_object_or_404(User, pk=pk)
-        edit_user.is_active = True
-        edit_user.save()
-        messages.success(self.request, _('The user was successfully activated'))
-        return reverse('core:user:overview', kwargs=({'pk': pk}))
 
 
 class UserEditView(

--- a/wger/gym/tests/test_user.py
+++ b/wger/gym/tests/test_user.py
@@ -350,6 +350,38 @@ class GymScopeGuardsTestCase(WgerTestCase):
         )
         self.assertEqual(response.status_code, 200)
 
+    def test_reset_password_get_does_not_mutate(self):
+        """
+        Regression test: GET must only render a confirmation form, since
+        Django's CSRF protection does not apply to GET requests. The actual
+        password reset must require POST.
+        """
+        victim = User.objects.get(pk=self.VICTIM_USER_PK)
+        old_password_hash = victim.password
+        self.user_login('manager1')
+
+        response = self.client.get(
+            reverse('gym:gym:reset-user-password', kwargs={'user_pk': self.VICTIM_USER_PK})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(User.objects.get(pk=self.VICTIM_USER_PK).password, old_password_hash)
+
+    def test_reset_password_post_mutates(self):
+        """
+        Sanity check: POST must perform the actual password reset.
+        """
+        victim = User.objects.get(pk=self.VICTIM_USER_PK)
+        old_password_hash = victim.password
+        self.user_login('manager1')
+
+        response = self.client.post(
+            reverse('gym:gym:reset-user-password', kwargs={'user_pk': self.VICTIM_USER_PK})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotEqual(User.objects.get(pk=self.VICTIM_USER_PK).password, old_password_hash)
+
     def test_permissions_edit_blocked_when_both_gyms_none(self):
         self._both_gyms_none(attacker_pk=9)
         self.user_login('manager1')

--- a/wger/gym/views/gym.py
+++ b/wger/gym/views/gym.py
@@ -20,6 +20,7 @@ import datetime
 import logging
 
 # Django
+from django import forms
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import (
     LoginRequiredMixin,
@@ -57,7 +58,11 @@ from django.views.generic import (
 # Third Party
 from allauth.account.models import EmailAddress
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import Submit
+from crispy_forms.layout import (
+    ButtonHolder,
+    Layout,
+    Submit,
+)
 
 # wger
 from wger.config.models import GymConfig as GlobalGymConfig
@@ -244,6 +249,10 @@ def gym_new_user_info_export(request):
 def reset_user_password(request, user_pk):
     """
     Resets the password of the selected user to random password
+
+    GET only renders a confirmation form: resetting a password is a state
+    change and must go through Django's CSRF protection, which only applies
+    to unsafe HTTP methods (e.g. POST), not GET.
     """
 
     user = get_object_or_404(User, pk=user_pk)
@@ -256,6 +265,25 @@ def reset_user_password(request, user_pk):
 
     if request.user.has_perm('gym.manage_gym') and not is_same_gym(request.user, user):
         return HttpResponseForbidden()
+
+    if request.method != 'POST':
+        form = forms.Form()
+        form.helper = FormHelper()
+        form.helper.form_method = 'post'
+        form.helper.form_action = request.path
+        form.helper.layout = Layout(
+            ButtonHolder(
+                Submit('submit', _('Yes, reset the password'), css_class='btn-warning btn-block')
+            )
+        )
+        return render(
+            request,
+            'delete.html',
+            {
+                'title': _('Reset the password for %(user)s?') % {'user': user},
+                'form': form,
+            },
+        )
 
     password = password_generator()
     user.set_password(password)

--- a/wger/gym/views/gym.py
+++ b/wger/gym/views/gym.py
@@ -278,9 +278,10 @@ def reset_user_password(request, user_pk):
         )
         return render(
             request,
-            'delete.html',
+            'confirm.html',
             {
-                'title': _('Reset the password for %(user)s?') % {'user': user},
+                'title': _('Reset the password for this user?'),
+                'confirm_message': str(user),
                 'form': form,
             },
         )


### PR DESCRIPTION
## Why

Three views performed sensitive state changes as a side effect of a GET request, with no confirmation step:

- `reset_user_password()` (`wger/gym/views/gym.py`) resets a user's password to a random value.
- `UserDeactivateView.get_redirect_url()` and `UserActivateView.get_redirect_url()` (`wger/core/views/user.py`) flip `is_active` on a user, both `RedirectView`s that mutated state while computing the redirect target for *any* request, including GET.

Django's CSRF protection only applies to unsafe HTTP methods (GET is exempt by design), so a third-party page could embed a link/image pointing at these URLs and, if loaded by an authenticated gym manager/trainer's browser (which sends the session cookie automatically), trigger a password reset or account deactivation without the manager's consent — a classic CSRF-via-state-changing-GET.

This codebase already has precedent for fixing this exact class of bug: `trainer_login` in `wger/core/views/user.py` was previously converted to `@require_POST`, with the comment "rebinding the session is a state change and must go through Django's CSRF protection, which only applies to unsafe HTTP methods." This PR applies the same principle to the three remaining GET-mutates endpoints.

## Fix

- `reset_user_password`: GET now renders a confirmation form (reusing the existing `delete.html` template + crispy-forms pattern already used elsewhere for delete confirmations); only POST performs the actual reset.
- `UserDeactivateView` / `UserActivateView`: converted from `RedirectView` (which mutated unconditionally) to a small shared `UserActivationConfirmMixin` with explicit `get()` (renders the same confirmation pattern) and `post()` (performs the actual `is_active` change). All existing permission checks in `dispatch()` are unchanged.
- Updated `wger/core/templates/user/overview.html`: the "Reset user password" dropdown item now uses the existing `modal_link` tag (the same htmx-into-modal confirmation mechanism already used for "Deactivate/Activate user" and "Delete"), instead of a bespoke modal + inline JS that did `window.location.href = url` (a GET navigation). This removes the one-off modal/script block entirely — no template/JS changes were needed for deactivate/activate since they already used `modal_link`; only their view-side GET handler needed to stop mutating.

## Testing

- Updated the existing `activate`/`deactivate` test helpers and `test_trainer_can_still_deactivate_regular_member` in `wger/core/tests/test_user.py` to POST (their "legitimate flow" assertions were unintentionally still relying on GET mutating state).
- Added `test_activate_get_does_not_mutate` / `test_deactivate_get_does_not_mutate` (regression: GET returns 200 and leaves `is_active` unchanged).
- Added `test_reset_password_get_does_not_mutate` / `test_reset_password_post_mutates` in `wger/gym/tests/test_user.py` (the existing `test_reset_password_allowed_same_gym` only checked the status code, never that GET actually left the password alone, or that POST does perform the reset).
- Ran the full `wger.core` and `wger.gym` test suites (511 tests) — all pass.
- Ran `ruff check` and `isort --check-only` on all changed files — clean.

I'm developing on Windows and used a portable CPython 3.12 build plus a local SQLite-backed run with `DJANGO_SETTINGS_MODULE=settings.ci` to execute the real test suite (rather than guessing at behavior), so this was tested against the actual fixtures and templates, not just read statically.

Fixes #2380.