### PR TITLE
Add endpoint to retrieve the currently active routine (fixes #2361)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,6 @@
 # Changelog for the next release
+
+* Added a `Routine.objects.active()` manager method and a
+  `GET /api/v2/routine/current/` endpoint that returns the routine currently
+  running (today within its start/end dates) instead of the most recently
+  created one, falling back to the latter when none is active (#2361)

--- a/wger/manager/api/views.py
+++ b/wger/manager/api/views.py
@@ -21,7 +21,10 @@ from django.core.cache import cache
 from django.db.models import Q
 
 # Third Party
-from rest_framework import viewsets
+from rest_framework import (
+    status,
+    viewsets,
+)
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
@@ -195,6 +198,21 @@ class RoutineViewSet(viewsets.ModelViewSet):
         cache.set(cache_key, out, settings.WGER_SETTINGS['ROUTINE_CACHE_TTL'])
 
         return Response(out)
+
+    @action(detail=False, url_path='current')
+    def current(self, request):
+        """
+        Return the routine that is currently active (today falls within its
+        start/end dates). Falls back to the most recently created routine if
+        none is currently active.
+        """
+        queryset = self.get_queryset().filter(is_template=False)
+        routine = queryset.active().first() or queryset.first()
+        if routine is None:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        serializer = self.get_serializer(routine)
+        return Response(serializer.data)
 
     @staticmethod
     def get_owner_objects():

--- a/wger/manager/managers.py
+++ b/wger/manager/managers.py
@@ -16,6 +16,7 @@
 
 # Django
 from django.db import models
+from django.utils import timezone
 
 # wger
 from wger.manager.consts import (
@@ -58,9 +59,20 @@ class WorkoutLogManager(models.Manager):
         return self.get_queryset().reps()
 
 
+class RoutineQuerySet(models.QuerySet):
+    def active(self):
+        """Return only routines whose date range includes today"""
+        today = timezone.localdate()
+        return self.filter(start__lte=today, end__gte=today)
+
+
 class RoutineManager(models.Manager):
     def get_queryset(self):
-        return super().get_queryset()
+        return RoutineQuerySet(self.model, using=self._db)
+
+    def active(self):
+        """Return only routines whose date range includes today"""
+        return self.get_queryset().active()
 
 
 class RoutineTemplateManager(models.Manager):

--- a/wger/manager/tests/test_routine.py
+++ b/wger/manager/tests/test_routine.py
@@ -18,7 +18,9 @@ from unittest import mock
 
 # Django
 from django.conf import settings
+from django.contrib.auth.models import User
 from django.urls import reverse
+from django.utils import timezone
 
 # wger
 from wger.core.tests.api_base_test import ApiBaseResourceTestCase
@@ -630,3 +632,131 @@ class RoutineLogsAndStatsScopeTestCase(WgerTestCase):
         self.user_login('test')
         response = self.client.get(self.detail_url)
         self.assertEqual(response.status_code, 200)
+
+
+class RoutineActiveDetectionTestCase(WgerTestCase):
+    """
+    A routine that is currently running (today falls within its start/end
+    dates) must be preferred over more recently created routines, both via
+    the model/manager helpers and the `/current/` API action.
+
+    See https://github.com/wger-project/wger/issues/2361
+    """
+
+    PASSWORD = 'active-detection-pw'
+
+    def setUp(self):
+        super().setUp()
+        self.today = timezone.localdate()
+        # Use a dedicated user without fixture routines so the assertions
+        # (especially the "no active routine" and fallback cases) don't
+        # depend on the state or dates of the shared test fixtures.
+        self.user = User.objects.create_user(
+            username='active-detection',
+            password=self.PASSWORD,
+        )
+
+    def _make_routine(self, name, start, end, is_template=False):
+        routine = Routine(
+            user=self.user,
+            name=name,
+            start=start,
+            end=end,
+            is_template=is_template,
+        )
+        routine.save()
+        return routine
+
+    def _login(self):
+        self.client.login(username=self.user.username, password=self.PASSWORD)
+
+    def test_manager_active_prefers_running_routine_over_newer_ones(self):
+        """
+        A routine created earlier but currently running must be returned by
+        `.active()`, even though a routine created afterwards (but scheduled
+        for the future) sorts first under the default `-start, -created`
+        ordering.
+        """
+        active = self._make_routine(
+            'currently running',
+            self.today - datetime.timedelta(days=5),
+            self.today + datetime.timedelta(days=5),
+        )
+        self._make_routine(
+            'created later, starts in the future',
+            self.today + datetime.timedelta(days=1),
+            self.today + datetime.timedelta(days=30),
+        )
+
+        result = Routine.objects.filter(user=self.user).active().first()
+        self.assertEqual(result, active)
+
+    def test_manager_active_returns_empty_queryset_when_none_is_running(self):
+        self._make_routine(
+            'past',
+            self.today - datetime.timedelta(days=20),
+            self.today - datetime.timedelta(days=10),
+        )
+
+        self.assertFalse(Routine.objects.filter(user=self.user).active().exists())
+
+    def test_api_current_returns_active_routine_over_most_recently_created(self):
+        active = self._make_routine(
+            'currently running',
+            self.today - datetime.timedelta(days=5),
+            self.today + datetime.timedelta(days=5),
+        )
+        self._make_routine(
+            'created later, starts in the future',
+            self.today + datetime.timedelta(days=1),
+            self.today + datetime.timedelta(days=30),
+        )
+
+        self._login()
+        response = self.client.get(reverse('routine-current'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['id'], active.id)
+
+    def test_api_current_falls_back_to_most_recent_when_none_active(self):
+        self._make_routine(
+            'older',
+            self.today - datetime.timedelta(days=20),
+            self.today - datetime.timedelta(days=10),
+        )
+        newest = self._make_routine(
+            'newest, but scheduled for the future',
+            self.today + datetime.timedelta(days=10),
+            self.today + datetime.timedelta(days=20),
+        )
+
+        self._login()
+        response = self.client.get(reverse('routine-current'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['id'], newest.id)
+
+    def test_api_current_ignores_templates(self):
+        self._make_routine(
+            'template, currently running',
+            self.today - datetime.timedelta(days=5),
+            self.today + datetime.timedelta(days=5),
+            is_template=True,
+        )
+        real = self._make_routine(
+            'real routine, not currently running',
+            self.today - datetime.timedelta(days=20),
+            self.today - datetime.timedelta(days=10),
+        )
+
+        self._login()
+        response = self.client.get(reverse('routine-current'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['id'], real.id)
+
+    def test_api_current_returns_404_when_user_has_no_routines(self):
+        self._login()
+        response = self.client.get(reverse('routine-current'))
+
+        self.assertEqual(response.status_code, 404)


### PR DESCRIPTION
The dashboard (web and app) shows the most recently created routine, even if
it hasn't started yet or already ended. The backend had no way to ask for the
routine that is actually running today.

# Proposed Changes

- `Routine.objects.active()`: returns routines whose start/end range includes
  today (same QuerySet+Manager pattern as `WorkoutLog`).
- `GET /api/v2/routine/current/`: returns the active routine (templates
  excluded). Falls back to the most recent one if none is active, 404 if the
  user has no routines.

Backend-only: clients need a follow-up to consume the new endpoint.

## Related Issue(s)

Closes #2361

## Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code has been formatted to avoid unnecessary diffs (`ruff format && isort .`)
- [x] If the feature is big enough or if there are manual steps needed (deployment changes etc.), write a small writeup in `CHANGELOG.md`