### PR TITLE
Make the PowerSync auth token lifetime configurable

### DIFF
--- a/settings/main.py
+++ b/settings/main.py
@@ -109,6 +109,7 @@ JWT_PUBLIC_KEY = env.str('JWT_PUBLIC_KEY', '')
 JWT_PRIVATE_KEY = env.str('JWT_PRIVATE_KEY', '')
 POWERSYNC_URL_PATH = env.str('POWERSYNC_URL_PATH', 'ps')
 POWERSYNC_URL = env.str('POWERSYNC_URL', '')
+POWERSYNC_ACCESS_TOKEN_EXPIRES_IN = env.int('POWERSYNC_ACCESS_TOKEN_EXPIRES_IN', 600)
 if not DEBUG and any(
     key and hashlib.sha256(key.encode()).hexdigest() in _DEFAULT_JWT_KEY_HASHES
     for key in (JWT_PUBLIC_KEY, JWT_PRIVATE_KEY)

--- a/settings/settings_global.py
+++ b/settings/settings_global.py
@@ -287,6 +287,11 @@ HEADLESS_TOKEN_STRATEGY = 'wger.utils.headless_auth.WgerJWTTokenStrategy'
 HEADLESS_JWT_ALGORITHM = 'RS256'
 HEADLESS_JWT_REFRESH_TOKEN_EXPIRES_IN = 120 * 24 * 3600
 
+# Lifetime (in seconds) of the JWT the app requests to authenticate against
+# the PowerSync service. Kept short by default; can be raised to reduce how
+# often the mobile client has to refresh the sync token.
+POWERSYNC_ACCESS_TOKEN_EXPIRES_IN = 600
+
 
 def jwk_b64_to_pem(b64_jwk_str: str):
     """

--- a/wger/core/api/powersync.py
+++ b/wger/core/api/powersync.py
@@ -52,7 +52,7 @@ def create_token(user_id):
             'sub': str(user_id),
             'iat': now,
             'aud': 'powersync',
-            'exp': now + 600,
+            'exp': now + settings.POWERSYNC_ACCESS_TOKEN_EXPIRES_IN,
         },
         _private_key(),
         algorithm=jwk['alg'],

--- a/wger/core/tests/test_powersync.py
+++ b/wger/core/tests/test_powersync.py
@@ -16,16 +16,23 @@
 from unittest import mock
 
 # Django
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import (
     IntegrityError,
     OperationalError,
 )
+from django.test import (
+    SimpleTestCase,
+    override_settings,
+)
 
 # Third Party
+import jwt
 from rest_framework import status
 
 # wger
+from wger.core.api.powersync import create_token
 from wger.core.models import UserProfile
 from wger.core.tests import powersync_base_test
 
@@ -113,3 +120,21 @@ class UserProfilePowerSyncTestCase(
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json().get('error'), 'Validation failed')
+
+
+class PowerSyncTokenLifetimeTestCase(SimpleTestCase):
+    """The PowerSync auth token honours POWERSYNC_ACCESS_TOKEN_EXPIRES_IN."""
+
+    @staticmethod
+    def _token_lifetime():
+        decoded = jwt.decode(create_token(1), options={'verify_signature': False})
+        return decoded['exp'] - decoded['iat']
+
+    def test_default_lifetime_matches_setting(self):
+        """With no override the token expiry equals the configured default."""
+        self.assertEqual(self._token_lifetime(), settings.POWERSYNC_ACCESS_TOKEN_EXPIRES_IN)
+
+    @override_settings(POWERSYNC_ACCESS_TOKEN_EXPIRES_IN=3600)
+    def test_setting_overrides_lifetime(self):
+        """Raising the setting lengthens the token accordingly."""
+        self.assertEqual(self._token_lifetime(), 3600)


### PR DESCRIPTION
## What

The JWT that the Flutter app requests to authenticate against the PowerSync service is created in `wger/core/api/powersync.py` with a **hard-coded 600 s (10 min) lifetime**:

```python
"exp": now + 600,
```

This PR makes that lifetime configurable via a new setting **`POWERSYNC_ACCESS_TOKEN_EXPIRES_IN`** (seconds), defaulting to the previous `600` so behaviour is unchanged out of the box. On the docker settings it is read from the environment, so self-hosters can raise it without patching the source.

## Why

On self-hosted instances the 10-minute lifetime forces the mobile client to refresh the sync token very frequently. When a refresh is missed (typically when the app resumes from the background after the token has already expired) the PowerSync stream can stall, and the only reliable recovery is clearing the app storage and logging in again. The server logs the expected `PSYNC_S2103 JWT has expired` on `/sync/stream` in those windows.

Being able to lengthen the token (e.g. to 1 h) sharply reduces how often the client sits with an expired token on resume, which reduces the frequency of these stalls, without any client-side change.

## Changes

- `settings/settings_global.py`: add `POWERSYNC_ACCESS_TOKEN_EXPIRES_IN = 600` default.
- `settings/main.py`: read `POWERSYNC_ACCESS_TOKEN_EXPIRES_IN` from the environment (docker deployments).
- `wger/core/api/powersync.py`: use the setting instead of the hard-coded `600`.
- `wger/core/tests/test_powersync.py`: add `PowerSyncTokenLifetimeTestCase` asserting the default and an override are honoured.

## Compatibility

Default is unchanged (600 s), so existing deployments behave exactly as before unless they opt in by setting the env var.