### PR TITLE
  Fix weight entry validation for imperial units

### DIFF
--- a/wger/weight/api/serializers.py
+++ b/wger/weight/api/serializers.py
@@ -15,11 +15,20 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Workout Manager.  If not, see <http://www.gnu.org/licenses/>.
 
+# Standard Library
+from decimal import Decimal
+
 # Third Party
 from rest_framework import serializers
 
 # wger
+from wger.utils.constants import TWOPLACES
+from wger.utils.units import AbstractWeight
 from wger.weight.models import WeightEntry
+
+
+MIN_WEIGHT_KG = Decimal(30)
+MAX_WEIGHT_KG = Decimal(600)
 
 
 class WeightEntrySerializer(serializers.ModelSerializer):
@@ -28,6 +37,26 @@ class WeightEntrySerializer(serializers.ModelSerializer):
     """
 
     user = serializers.PrimaryKeyRelatedField(read_only=True)
+    weight = serializers.DecimalField(max_digits=7, decimal_places=2)
+
+    def validate_weight(self, value):
+        request = self.context.get('request')
+        user = getattr(request, 'user', None)
+        weight_unit = getattr(getattr(user, 'userprofile', None), 'weight_unit', 'kg')
+
+        weight = AbstractWeight(value, weight_unit).kg.quantize(TWOPLACES)
+
+        if weight < MIN_WEIGHT_KG:
+            raise serializers.ValidationError(
+                f'Ensure this value is greater than or equal to {MIN_WEIGHT_KG}.'
+            )
+
+        if weight > MAX_WEIGHT_KG:
+            raise serializers.ValidationError(
+                f'Ensure this value is less than or equal to {MAX_WEIGHT_KG}.'
+            )
+
+        return weight
 
     class Meta:
         model = WeightEntry

--- a/wger/weight/tests/test_entry.py
+++ b/wger/weight/tests/test_entry.py
@@ -12,8 +12,15 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 
+# Standard Library
+from decimal import Decimal
+
 # Django
+from django.contrib.auth.models import User
 from django.utils import timezone
+
+# Third Party
+from rest_framework import status
 
 # wger
 from wger.core.tests import api_base_test
@@ -45,3 +52,33 @@ class WeightEntryTestCase(api_base_test.ApiBaseResourceTestCase):
     private_resource = True
     date = timezone.now() - timezone.timedelta(days=25)
     data = {'weight': 100, 'date': date}
+
+    def test_post_imperial_weight_is_converted_to_kg(self):
+        """
+        Test that users using lb can submit body weight in lb.
+        """
+        self.authenticate('trainer4')
+
+        response = self.client.post(
+            self.url,
+            data={'weight': 365, 'date': self.date},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        entry = WeightEntry.objects.get(pk=response.data['id'])
+        self.assertEqual(entry.user, User.objects.get(username='trainer4'))
+        self.assertEqual(entry.weight, Decimal('165.56'))
+
+    def test_post_imperial_weight_above_kg_limit_fails(self):
+        """
+        Test that lb input is still validated against the kg storage limit.
+        """
+        self.authenticate('trainer4')
+
+        response = self.client.post(
+            self.url,
+            data={'weight': 1323, 'date': self.date},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('weight', response.data)


### PR DESCRIPTION
# Proposed Changes

  - Fix weight entry validation for users using imperial units (`lb`) by converting submitted values to kilograms before applying the stored kg limits.
  - Add API tests covering successful imperial weight submission and rejection of values that exceed the kg storage limit after conversion.

  ## Related Issue(s)

Closes #2374

  ## Please check that the PR fulfills these requirements

  - [x] Tests for the changes have been added (for bug fixes / features)
  - [X] Code has been formatted to avoid unnecessary diffs (`ruff format && isort .`)
  - [ ] If the feature is big enough or if there are manual steps needed (deployment
    changes etc.), write a small writeup in `CHANGELOG.md`