### PR TITLE
feat: add documentation links to Features page

### DIFF
--- a/wger/software/templates/features.html
+++ b/wger/software/templates/features.html
@@ -186,6 +186,13 @@
                                 {% translate "Keep track of the workouts you've done, including how you felt you performed" %}
                             </li>
                         </ul>
+                        <p class="mt-3 mb-0">
+                            <a href="https://wger.readthedocs.io/en/latest/manual/routines.html"
+                                target="_blank"
+                                rel="noopener noreferrer">
+                                {% translate "Documentation" %}
+                            </a>
+                        </p>
                     </div>
                 </div>
             </section>
@@ -226,6 +233,13 @@
                                 {% endblocktranslate %}
                             </li>
                         </ul>
+                        <p class="mt-3 mb-0">
+                            <a href="https://wger.readthedocs.io/en/latest/"
+                                target="_blank"
+                                rel="noopener noreferrer">
+                                {% translate "Documentation" %}
+                            </a>
+                        </p>
                     </div>
                 </div>
             </section>
@@ -268,6 +282,13 @@
                                 {% translate "Use the calendar view to see past entries" %}
                             </li>
                         </ul>
+                        <p class="mt-3 mb-0">
+                            <a href="https://wger.readthedocs.io/en/latest/"
+                                target="_blank"
+                                rel="noopener noreferrer">
+                                {% translate "Documentation" %}
+                            </a>
+                        </p>
                     </div>
                 </div>
 


### PR DESCRIPTION
Add 'Learn more in the documentation' links under the main feature sections so new users can jump directly to the relevant docs.

<!-- Thank you for contributing! If you want to suggest a new feature, please -->
<!-- discuss it first, either by opening a new issue, asking on an existing   -->
<!-- one, or on discord. -->

# Proposed Changes

- Added "Learn more in the documentation" links under the three main feature sections on the Features page:
  - Workout routines → https://wger.readthedocs.io/en/latest/manual/routines.html
  - Nutrition tracking → https://wger.readthedocs.io/en/latest/
  - Progress tracking → https://wger.readthedocs.io/en/latest/
- All new strings use `{% translate %}` so they remain translatable
- Links open in a new tab with `rel="noopener noreferrer"`

## Related Issue(s)

Closes #2442

## Please check that the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code has been formatted to avoid unnecessary diffs (`ruff format && isort .`)
- [ ] If the feature is big enough or if there are manual steps needed (deployment
  changes etc.), write a small writeup in `CHANGELOG.md`