### PR TITLE
fix(manager): advance gated progression exactly one step per qualifying iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,7 @@
 # Changelog for the next release
+
+## Bug fixes
+
+* Gated progressions (configs with `requirements`) now advance exactly one step
+  per qualifying workout instead of back-filling increments for skipped,
+  non-qualifying iterations

--- a/wger/manager/models/slot_entry.py
+++ b/wger/manager/models/slot_entry.py
@@ -471,7 +471,10 @@ class SlotEntry(models.Model):
                         _requirement_met(log, req_field) for req_field in requirements.rules
                     )
                     if all_fields_met:
-                        max_iterations[field] = i
+                        # Advance exactly one earned increment per qualifying iteration
+                        # instead of jumping to the calendar index, which would
+                        # back-fill increments for skipped, non-qualifying iterations.
+                        max_iterations[field] += 1
                         break
 
         sets = self.calculate_sets(max_iterations['sets'])

--- a/wger/manager/tests/test_slot_entry.py
+++ b/wger/manager/tests/test_slot_entry.py
@@ -530,6 +530,85 @@ class SlotEntryTestCase(WgerTestCase):
         self.assertEqual(config_data.rir, None)
         self.assertEqual(config_data.weight, 80)
 
+    def _setup_gated_weight_progression(self):
+        """
+        Base weight of 20, +2.5 kg per iteration (repeating), gated on reaching
+        the prescribed 5 repetitions
+        """
+        self.slot_entry.weight_rounding = 2.5
+        self.slot_entry.save()
+
+        RepetitionsConfig(slot_entry=self.slot_entry, iteration=1, value=5).save()
+        WeightConfig(
+            slot_entry=self.slot_entry,
+            iteration=1,
+            value=20,
+        ).save()
+        WeightConfig(
+            slot_entry=self.slot_entry,
+            iteration=2,
+            value=2.5,
+            operation=OperationChoices.PLUS,
+            step=StepChoices.ABSOLUTE,
+            repeat=True,
+            requirements={'rules': ['repetitions']},
+        ).save()
+
+    def _log_repetitions(self, iteration: int, repetitions: int):
+        WorkoutLog(
+            exercise_id=1,
+            user_id=1,
+            routine_id=1,
+            slot_entry=self.slot_entry,
+            iteration=iteration,
+            weight=20,
+            repetitions=repetitions,
+        ).save()
+
+    def test_requirements_no_backfill_after_skipped_iteration(self):
+        """
+        A gated progression only advances one step per qualifying iteration and
+        doesn't back-fill increments for skipped, non-qualifying iterations
+        """
+        self._setup_gated_weight_progression()
+
+        # Didn't qualify at iteration 1, qualified at iteration 2
+        self._log_repetitions(iteration=1, repetitions=3)
+        self._log_repetitions(iteration=2, repetitions=5)
+
+        # No increment earned yet at iteration 2
+        self.assertEqual(self.slot_entry.get_config_data(2).weight, Decimal(20))
+
+        # Iteration 3 prescribes exactly one earned increment, not two
+        self.assertEqual(self.slot_entry.get_config_data(3).weight, Decimal('22.5'))
+
+    def test_requirements_gap_between_qualifications(self):
+        """
+        Qualifying at iterations 2 and 4 only earns exactly two increments
+        """
+        self._setup_gated_weight_progression()
+
+        self._log_repetitions(iteration=1, repetitions=3)
+        self._log_repetitions(iteration=2, repetitions=5)
+        self._log_repetitions(iteration=3, repetitions=3)
+        self._log_repetitions(iteration=4, repetitions=5)
+
+        self.assertEqual(self.slot_entry.get_config_data(5).weight, Decimal(25))
+
+    def test_requirements_continuous_qualification(self):
+        """
+        Qualifying at every iteration advances the progression at full speed
+        """
+        self._setup_gated_weight_progression()
+
+        self._log_repetitions(iteration=1, repetitions=5)
+        self._log_repetitions(iteration=2, repetitions=5)
+        self._log_repetitions(iteration=3, repetitions=5)
+
+        self.assertEqual(self.slot_entry.get_config_data(2).weight, Decimal('22.5'))
+        self.assertEqual(self.slot_entry.get_config_data(3).weight, Decimal(25))
+        self.assertEqual(self.slot_entry.get_config_data(4).weight, Decimal('27.5'))
+
     def test_weight_config_with_logs_and_range(self):
         """
         Test that the weight is correctly calculated for each step / iteration


### PR DESCRIPTION
# Proposed Changes

- Fix gated progression back-filling skipped iterations: when a config's
  progression is gated by `requirements`, the met-branch in
  `SlotEntry.get_config_data()` jumped the advancement pointer to the calendar
  iteration index, so `calculate_X()` credited increments for skipped,
  non-qualifying iterations. A user qualifying only at iteration 2 (base 20 kg,
  +2.5 repeating) was prescribed 25 kg at iteration 3 instead of 22.5 kg.
- Advance the pointer exactly one step per qualifying iteration instead.
  Continuous qualification is unchanged (base + (n - 1) * increment); the
  ungated branch is untouched.
- Add regression tests: intermittent qualification, gaps between
  qualifications, and a continuous-qualification guard (mutation-checked:
  the first two fail on the previous code).

## Related Issue(s)

Closes #2464

## Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code has been formatted to avoid unnecessary diffs (`ruff format && isort .`)
- [x] CHANGELOG.md entry added (Bug fixes)
