### PR TITLE
refactor(manager): Remove day-id inference workaround from WorkoutLog.save() (#2481)

### DIFF
--- a/wger/manager/models/log.py
+++ b/wger/manager/models/log.py
@@ -271,18 +271,11 @@ class WorkoutLog(models.Model):
 
         # Auto-create a session only if the client didn't provide one.
         if not self.session_id:
-            # The day is only a default: an existing session for the date keeps
-            # its day, and the (user, date, routine) dedup semantics stay unchanged.
-            day = None
-            if self.slot_entry and self.slot_entry.slot.day.routine_id == self.routine_id:
-                day = self.slot_entry.slot.day
-
             try:
                 self.session = WorkoutSession.objects.get_or_create(
                     user=self.user,
                     date=self.date,
                     routine=self.routine,
-                    defaults={'day': day},
                 )[0]
             except WorkoutSession.MultipleObjectsReturned:
                 # TODO: duplicate sessions can exist for the same (user, date, routine)
@@ -307,23 +300,3 @@ class WorkoutLog(models.Model):
 
         # Save to db
         super().save(*args, **kwargs)
-
-        # The app creates its sessions itself and can leave the day empty, which
-        # hides them from days with need_logs_to_advance. Only filled in when all
-        # logs of the session agree on one day, like migration 0028 does: a wrong
-        # day would open the gate on a day the user never trained.
-        #
-        # Can be removed once the app versions that set the day are widely adopted.
-        if self.session_id and self.slot_entry and self.session.day_id is None:
-            days = list(
-                WorkoutLog.objects.filter(
-                    session_id=self.session_id,
-                    slot_entry__isnull=False,
-                )
-                .values_list('slot_entry__slot__day_id', 'slot_entry__slot__day__routine_id')
-                .distinct()
-            )
-
-            if len(days) == 1 and days[0][1] == self.session.routine_id:
-                self.session.day_id = days[0][0]
-                self.session.save(update_fields=['day'])

--- a/wger/manager/tests/test_log_model.py
+++ b/wger/manager/tests/test_log_model.py
@@ -52,27 +52,6 @@ class LogModelTestCase(WgerTestCase):
 
         self.assertEqual(WorkoutSession.objects.count(), 1)
 
-    def test_create_session_sets_day(self):
-        """
-        The auto-created session inherits the day of the log's slot entry, so
-        that need_logs_to_advance days can find it
-        """
-
-        WorkoutLog.objects.all().delete()
-        WorkoutSession.objects.all().delete()
-
-        WorkoutLog(
-            user_id=1,
-            exercise_id=1,
-            routine_id=1,
-            slot_entry_id=1,
-            weight=10,
-            repetitions=10,
-        ).save()
-
-        session = WorkoutSession.objects.get()
-        self.assertEqual(session.day_id, 1)
-
     def test_create_session_without_slot_entry_has_no_day(self):
         """
         A free log without a slot entry can't know its day
@@ -90,28 +69,6 @@ class LogModelTestCase(WgerTestCase):
 
         session = WorkoutSession.objects.get()
         self.assertIsNone(session.day_id)
-
-    def test_fills_missing_day_on_a_client_created_session(self):
-        """
-        A session the client created without a day gets it from the log, so that
-        need_logs_to_advance days can find it
-        """
-
-        session = WorkoutSession.objects.get(pk='bbbbbbbb-bbbb-bbbb-bbbb-000000000001')
-        self.assertIsNone(session.day_id)
-
-        WorkoutLog(
-            user_id=1,
-            exercise_id=1,
-            routine_id=1,
-            slot_entry_id=1,
-            session=session,
-            weight=10,
-            repetitions=10,
-        ).save()
-
-        session.refresh_from_db()
-        self.assertEqual(session.day_id, 1)
 
     def test_does_not_overwrite_the_day_of_a_session(self):
         """
@@ -135,112 +92,6 @@ class LogModelTestCase(WgerTestCase):
 
         session.refresh_from_db()
         self.assertEqual(session.day_id, 3)
-
-    def test_does_not_fill_the_day_when_the_logs_span_several_days(self):
-        """
-        A session whose logs come from more than one day stays without one, since
-        no single day is the right answer
-        """
-
-        session = WorkoutSession.objects.get(pk='bbbbbbbb-bbbb-bbbb-bbbb-000000000001')
-        self.assertIsNone(session.day_id)
-
-        # A second entry, on another day of the same routine
-        other_slot = Slot.objects.create(day_id=3, order=1)
-        other_entry = SlotEntry.objects.create(slot=other_slot, exercise_id=1, order=1)
-
-        WorkoutLog(
-            user_id=1,
-            exercise_id=1,
-            routine_id=1,
-            slot_entry_id=1,
-            session=session,
-            weight=10,
-            repetitions=10,
-        ).save()
-
-        session.refresh_from_db()
-        self.assertEqual(session.day_id, 1)
-
-        # The day of the first log is no longer the whole truth, but an already
-        # set day is never taken away again
-        WorkoutLog(
-            user_id=1,
-            exercise_id=1,
-            routine_id=1,
-            slot_entry=other_entry,
-            session=session,
-            weight=10,
-            repetitions=10,
-        ).save()
-
-        session.refresh_from_db()
-        self.assertEqual(session.day_id, 1)
-
-    def test_does_not_fill_the_day_when_earlier_logs_disagree(self):
-        """
-        Logs that were already there decide as well, not just the one being saved
-        """
-
-        session = WorkoutSession.objects.get(pk='bbbbbbbb-bbbb-bbbb-bbbb-000000000001')
-        other_slot = Slot.objects.create(day_id=3, order=1)
-        other_entry = SlotEntry.objects.create(slot=other_slot, exercise_id=1, order=1)
-
-        # Two logs from different days, written without going through save()
-        for slot_entry_id in (1, other_entry.pk):
-            WorkoutLog.objects.bulk_create(
-                [
-                    WorkoutLog(
-                        user_id=1,
-                        exercise_id=1,
-                        routine_id=1,
-                        slot_entry_id=slot_entry_id,
-                        session=session,
-                        weight=10,
-                        repetitions=10,
-                    )
-                ]
-            )
-
-        session.refresh_from_db()
-        self.assertIsNone(session.day_id)
-
-        WorkoutLog(
-            user_id=1,
-            exercise_id=1,
-            routine_id=1,
-            slot_entry_id=1,
-            session=session,
-            weight=20,
-            repetitions=8,
-        ).save()
-
-        session.refresh_from_db()
-        self.assertIsNone(session.day_id)
-
-    def test_does_not_fill_the_day_from_another_routine(self):
-        """
-        The day of a slot entry from a different routine must not leak into the
-        session
-        """
-
-        session = WorkoutSession.objects.get(pk='bbbbbbbb-bbbb-bbbb-bbbb-000000000003')
-        self.assertIsNone(session.day_id)
-        self.assertEqual(session.routine_id, 2)
-
-        # slot entry 1 lives in routine 1, the session in routine 2
-        WorkoutLog(
-            user_id=1,
-            exercise_id=1,
-            routine_id=1,
-            slot_entry_id=1,
-            session=session,
-            weight=10,
-            repetitions=10,
-        ).save()
-
-        session.refresh_from_db()
-        self.assertIsNone(session.day_id)
 
     def test_save_reuses_session_when_duplicates_exist(self):
         """


### PR DESCRIPTION
<!-- Thank you for contributing! If you want to suggest a new feature, please -->
<!-- discuss it first, either by opening a new issue, asking on an existing   -->
<!-- one, or on discord. -->

# Proposed Changes


Removes the day-inference workaround added for #2460 . `WorkoutLog.save()` no longer guesses a session's `day` from `slot_entry → slot → day`, either when auto-creating a session or by re-scanning a session's logs after save. `day` is now only ever set from what's explicitly provided — no more extra per-save queries.

Migration `0028_backfill_session_day.py` is left untouched; 

**Tests:** updated `test_log_model.py` — removed inference-behavior tests,


## Related Issue(s)

<!-- If applicable, link to any related issues "Closes #123",    -->
<!-- "Closes wger-project/other-repo#123", "See also #123", etc. -->

Closes #2481.

## Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code has been formatted to avoid unnecessary diffs (`ruff format && isort .`)
- [ ] If the feature is big enough or if there are manual steps needed (deployment
  changes etc.), write a small writeup in `CHANGELOG.md`
