### PR TITLE
Improve ingredient search relevance for long names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ is switched off by default unless configured, see the docs for the setup.
 
 ## Bug fixes
 
+* Ingredient search now finds matching words in long ingredient names and ranks
+  more relevant results first
 * Gated progressions (configs with `requirements`) now advance exactly one step
   per qualifying workout instead of back-filling increments for skipped,
   non-qualifying iterations

--- a/wger/nutrition/api/filtersets.py
+++ b/wger/nutrition/api/filtersets.py
@@ -17,7 +17,10 @@
 import logging
 
 # Django
-from django.contrib.postgres.search import TrigramSimilarity
+from django.contrib.postgres.search import (
+    TrigramSimilarity,
+    TrigramStrictWordSimilarity,
+)
 from django.db.models import (
     Case,
     F,
@@ -39,6 +42,7 @@ from wger.nutrition.models import (
 from wger.utils.db import (
     PostgresILikeContains,
     PostgresILikeExact,
+    PostgresILikeStartsWith,
     is_postgres_db,
 )
 from wger.utils.language import load_language
@@ -113,27 +117,39 @@ class IngredientFilterSet(filters.FilterSet):
                 return barcode_qs
 
         if is_postgres_db():
+            if not any(character.isalnum() for character in value):
+                return queryset.none()
+
             # A trigram index cannot accelerate unrestricted one- or two-character
             # substring patterns. Exact matching still supports valid short names.
             if len(value) < 3:
                 exact = PostgresILikeExact(F('name'), value)
                 return queryset.filter(exact).order_by('name')
 
+            exact = PostgresILikeExact(F('name'), value)
+            starts_with = PostgresILikeStartsWith(F('name'), value)
+            contains = PostgresILikeContains(F('name'), value)
+
             candidates = Q(name__trigram_similar=value)
-            if _has_literal_trigram(value):
-                candidates |= PostgresILikeContains(F('name'), value)
+            # Whole-name similarity already retrieves specific multi-word queries;
+            # the extra substring scan is useful for single terms in long names.
+            if len(value.split(maxsplit=1)) == 1 and _has_literal_trigram(value):
+                candidates |= contains
 
             return (
                 queryset.filter(candidates)
                 .annotate(
+                    word_similarity=TrigramStrictWordSimilarity(value, 'name'),
+                    similarity=TrigramSimilarity('name', value),
+                )
+                .annotate(
                     match_rank=Case(
-                        When(name__iexact=value, then=Value(3)),
-                        When(name__istartswith=value, then=Value(2)),
-                        When(name__icontains=value, then=Value(1)),
+                        When(exact, then=Value(3)),
+                        When(starts_with, then=Value(2)),
+                        When(word_similarity=1, then=Value(1)),
                         default=Value(0),
                         output_field=IntegerField(),
                     ),
-                    similarity=TrigramSimilarity('name', value),
                 )
                 .order_by('-match_rank', '-similarity', 'name')
             )

--- a/wger/nutrition/api/filtersets.py
+++ b/wger/nutrition/api/filtersets.py
@@ -17,7 +17,10 @@
 import logging
 
 # Django
-from django.contrib.postgres.search import TrigramSimilarity
+from django.contrib.postgres.search import (
+    TrigramSimilarity,
+    TrigramWordSimilarity,
+)
 
 # Third Party
 from django_filters import rest_framework as filters
@@ -99,9 +102,12 @@ class IngredientFilterSet(filters.FilterSet):
             #     cursor.execute('SET LOCAL pg_trgm.similarity_threshold = 0.15')
 
             return (
-                queryset.filter(name__trigram_similar=value)
-                .annotate(similarity=TrigramSimilarity('name', value))
-                .order_by('-similarity', 'name')
+                queryset.filter(name__trigram_word_similar=value)
+                .annotate(
+                    word_similarity=TrigramWordSimilarity(value, 'name'),
+                    similarity=TrigramSimilarity('name', value),
+                )
+                .order_by('-word_similarity', '-similarity', 'name')
             )
         else:
             # Explicit order_by('name') because the viewset strips Meta.ordering.

--- a/wger/nutrition/api/filtersets.py
+++ b/wger/nutrition/api/filtersets.py
@@ -38,12 +38,23 @@ from wger.nutrition.models import (
 )
 from wger.utils.db import (
     PostgresILikeContains,
+    PostgresILikeExact,
     is_postgres_db,
 )
 from wger.utils.language import load_language
 
 
 logger = logging.getLogger(__name__)
+
+
+def _has_literal_trigram(value: str) -> bool:
+    """Return whether a substring lookup has a guaranteed indexable trigram."""
+    consecutive = 0
+    for character in value:
+        consecutive = consecutive + 1 if character.isalnum() else 0
+        if consecutive == 3:
+            return True
+    return False
 
 
 class LogItemFilterSet(filters.FilterSet):
@@ -102,9 +113,18 @@ class IngredientFilterSet(filters.FilterSet):
                 return barcode_qs
 
         if is_postgres_db():
-            contains = PostgresILikeContains(F('name'), value)
+            # A trigram index cannot accelerate unrestricted one- or two-character
+            # substring patterns. Exact matching still supports valid short names.
+            if len(value) < 3:
+                exact = PostgresILikeExact(F('name'), value)
+                return queryset.filter(exact).order_by('name')
+
+            candidates = Q(name__trigram_similar=value)
+            if _has_literal_trigram(value):
+                candidates |= PostgresILikeContains(F('name'), value)
+
             return (
-                queryset.filter(contains | Q(name__trigram_similar=value))
+                queryset.filter(candidates)
                 .annotate(
                     match_rank=Case(
                         When(name__iexact=value, then=Value(3)),

--- a/wger/nutrition/api/filtersets.py
+++ b/wger/nutrition/api/filtersets.py
@@ -17,9 +17,14 @@
 import logging
 
 # Django
-from django.contrib.postgres.search import (
-    TrigramSimilarity,
-    TrigramWordSimilarity,
+from django.contrib.postgres.search import TrigramSimilarity
+from django.db.models import (
+    Case,
+    F,
+    IntegerField,
+    Q,
+    Value,
+    When,
 )
 
 # Third Party
@@ -31,7 +36,10 @@ from wger.nutrition.models import (
     Ingredient,
     LogItem,
 )
-from wger.utils.db import is_postgres_db
+from wger.utils.db import (
+    PostgresILikeContains,
+    is_postgres_db,
+)
 from wger.utils.language import load_language
 
 
@@ -94,20 +102,20 @@ class IngredientFilterSet(filters.FilterSet):
                 return barcode_qs
 
         if is_postgres_db():
-            # Note: this uses the default value for pg_trgm.similarity_threshold (0.3) which
-            # might be too strict (doesn't find "butter" from "buttr"). If this needs to be
-            # changed later, e.g.:
-
-            # with connection.cursor() as cursor:
-            #     cursor.execute('SET LOCAL pg_trgm.similarity_threshold = 0.15')
-
+            contains = PostgresILikeContains(F('name'), value)
             return (
-                queryset.filter(name__trigram_word_similar=value)
+                queryset.filter(contains | Q(name__trigram_similar=value))
                 .annotate(
-                    word_similarity=TrigramWordSimilarity(value, 'name'),
+                    match_rank=Case(
+                        When(name__iexact=value, then=Value(3)),
+                        When(name__istartswith=value, then=Value(2)),
+                        When(name__icontains=value, then=Value(1)),
+                        default=Value(0),
+                        output_field=IntegerField(),
+                    ),
                     similarity=TrigramSimilarity('name', value),
                 )
-                .order_by('-word_similarity', '-similarity', 'name')
+                .order_by('-match_rank', '-similarity', 'name')
             )
         else:
             # Explicit order_by('name') because the viewset strips Meta.ordering.

--- a/wger/nutrition/tests/test_ingredient.py
+++ b/wger/nutrition/tests/test_ingredient.py
@@ -281,7 +281,9 @@ class IngredientSearchTestCase(WgerTestCase):
 
         self.assertEqual(result['count'], 2)
 
-        ingredient_1 = result['results'][0]
+        ingredients = {ingredient['id']: ingredient for ingredient in result['results']}
+
+        ingredient_1 = ingredients[2]
         self.assertEqual(ingredient_1['id'], 2)
         self.assertEqual(ingredient_1['name'], 'Ingredient, test, 2, organic, raw')
         self.assertEqual(ingredient_1['uuid'], '44dc5966-73a2-4df7-8b15-f6d37a8990d9')
@@ -289,7 +291,7 @@ class IngredientSearchTestCase(WgerTestCase):
         self.assertEqual(ingredient_1['image'], None)
         self.assertEqual(ingredient_1['thumbnails'], None)
 
-        ingredient_2 = result['results'][1]
+        ingredient_2 = ingredients[1]
         self.assertEqual(ingredient_2['id'], 1)
         self.assertEqual(ingredient_2['name'], 'Test ingredient 1')
         self.assertEqual(ingredient_2['uuid'], '7908c204-907f-4b1e-ad4e-f482e9769ade')

--- a/wger/nutrition/tests/test_search_api.py
+++ b/wger/nutrition/tests/test_search_api.py
@@ -14,7 +14,11 @@
 # along with Workout Manager.  If not, see <http://www.gnu.org/licenses/>.
 
 # Standard Library
+from unittest import skipUnless
 from unittest.mock import patch
+
+# Django
+from django.db import connection
 
 # Third Party
 from rest_framework import status
@@ -251,3 +255,107 @@ class SearchIngredientApiTestCase(BaseTestCase, ApiBaseTestCase):
         mock_fetch.assert_called_once_with('0000000000000')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 0)
+
+
+@skipUnless(connection.vendor == 'postgresql', 'PostgreSQL ingredient search only')
+class IngredientSearchRankingApiTestCase(BaseTestCase, ApiBaseTestCase):
+    """Regression tests for ingredient search retrieval and ranking."""
+
+    url = '/api/v2/ingredient/'
+
+    corpus = (
+        'Chicken',
+        'Chicken, Boiled Without Salt',
+        "'Nduja Chicken, Mozzarella, Slow Roast Tomato Sandwich",
+        'Chickpea Salad',
+        'Lunch out (placeholder)',
+        'Pasta Carbonara, Bacon',
+        '"Oat Milk Mocha" Oat Milk Latte Bar',
+        'Milk',
+        'Rice',
+        'Rice Pudding',
+        'Salty Liquorice',
+        'Banana',
+        'Banana Bread',
+        'Salmon',
+        'Smoked Salmon',
+    )
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        for name in cls.corpus:
+            Ingredient.objects.create(
+                name=name,
+                source_name='Test',
+                language_id=2,
+                energy=100,
+                protein=10,
+                carbohydrates=10,
+                fat=10,
+            )
+
+    def search_names(self, query):
+        response = self.client.get(
+            self.url,
+            {'name__search': query, 'language__code': 'en'},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return [result['name'] for result in response.data['results']]
+
+    def assert_ranked_before(self, names, first, second):
+        self.assertIn(first, names)
+        self.assertIn(second, names)
+        self.assertLess(names.index(first), names.index(second))
+
+    def test_search_finds_words_in_long_ingredient_names(self):
+        cases = (
+            ('chicken', 'Chicken, Boiled Without Salt'),
+            ('chicken', "'Nduja Chicken, Mozzarella, Slow Roast Tomato Sandwich"),
+            ('lunch', 'Lunch out (placeholder)'),
+            ('pasta', 'Pasta Carbonara, Bacon'),
+            ('milk', '"Oat Milk Mocha" Oat Milk Latte Bar'),
+            ('rice', 'Rice Pudding'),
+            ('banana', 'Banana Bread'),
+            ('salmon', 'Smoked Salmon'),
+        )
+
+        for query, expected_name in cases:
+            with self.subTest(query=query, expected_name=expected_name):
+                names = self.search_names(query)
+                self.assertIn(expected_name, names)
+
+    def test_search_ranks_exact_names_first(self):
+        cases = ('Chicken', 'Milk', 'Rice', 'Banana', 'Salmon')
+
+        for expected_name in cases:
+            with self.subTest(expected_name=expected_name):
+                names = self.search_names(expected_name.lower())
+                self.assertEqual(names[:1], [expected_name])
+
+    def test_search_ranks_leading_matches_before_later_word_matches(self):
+        names = self.search_names('chicken')
+
+        self.assertEqual(names[:1], ['Chicken'])
+        self.assert_ranked_before(
+            names,
+            'Chicken, Boiled Without Salt',
+            "'Nduja Chicken, Mozzarella, Slow Roast Tomato Sandwich",
+        )
+
+    def test_search_supports_partial_words(self):
+        names = self.search_names('chick')
+
+        self.assertIn('Chicken', names)
+        self.assertIn('Chickpea Salad', names)
+
+    def test_search_finds_a_correctly_spelled_name_from_a_typo(self):
+        names = self.search_names('chickn')
+
+        self.assertEqual(names[:1], ['Chicken'])
+
+    def test_search_ranks_whole_words_above_inside_word_matches(self):
+        names = self.search_names('rice')
+
+        self.assert_ranked_before(names, 'Rice', 'Salty Liquorice')
+        self.assert_ranked_before(names, 'Rice Pudding', 'Salty Liquorice')

--- a/wger/nutrition/tests/test_search_api.py
+++ b/wger/nutrition/tests/test_search_api.py
@@ -37,12 +37,13 @@ class SearchIngredientApiTestCase(BaseTestCase, ApiBaseTestCase):
         Logged-out users are also allowed to use the search
         """
         response = self.client.get(self.url + '?name__search=test&language__code=en')
-        result1 = response.data['results'][0]
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 2)
-        self.assertEqual(result1['name'], 'Ingredient, test, 2, organic, raw')
-        self.assertEqual(result1['id'], 2)
+        self.assertCountEqual(
+            [(result['id'], result['name']) for result in response.data['results']],
+            [(1, 'Test ingredient 1'), (2, 'Ingredient, test, 2, organic, raw')],
+        )
 
     def test_basic_search_logged_in(self):
         """
@@ -50,12 +51,13 @@ class SearchIngredientApiTestCase(BaseTestCase, ApiBaseTestCase):
         """
         self.authenticate('test')
         response = self.client.get(self.url + '?name__search=test&language__code=en')
-        result1 = response.data['results'][0]
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 2)
-        self.assertEqual(result1['name'], 'Ingredient, test, 2, organic, raw')
-        self.assertEqual(result1['id'], 2)
+        self.assertCountEqual(
+            [(result['id'], result['name']) for result in response.data['results']],
+            [(1, 'Test ingredient 1'), (2, 'Ingredient, test, 2, organic, raw')],
+        )
 
     def test_search_language_code_en_no_results(self):
         """
@@ -351,6 +353,11 @@ class IngredientSearchRankingApiTestCase(BaseTestCase, ApiBaseTestCase):
 
     def test_search_finds_a_correctly_spelled_name_from_a_typo(self):
         names = self.search_names('chickn')
+
+        self.assertEqual(names[:1], ['Chicken'])
+
+    def test_search_preserves_typo_matches_from_whole_name_similarity(self):
+        names = self.search_names('chiken')
 
         self.assertEqual(names[:1], ['Chicken'])
 

--- a/wger/nutrition/tests/test_search_api.py
+++ b/wger/nutrition/tests/test_search_api.py
@@ -278,10 +278,16 @@ class IngredientSearchRankingApiTestCase(BaseTestCase, ApiBaseTestCase):
         'Rice',
         'Rice Pudding',
         'Salty Liquorice',
+        'Brown rice, long grain, cooked without salt',
+        'Licorice',
         'Banana',
         'Banana Bread',
         'Salmon',
         'Smoked Salmon',
+        'İstanbul',
+        'Istanbul spice',
+        'Butter',
+        'Apple Buttrr Spread',
         '餅',
         '牛乳',
     )
@@ -320,6 +326,7 @@ class IngredientSearchRankingApiTestCase(BaseTestCase, ApiBaseTestCase):
     def test_search_finds_words_in_long_ingredient_names(self):
         cases = (
             ('chicken', 'Chicken, Boiled Without Salt'),
+            ('chicken boiled', 'Chicken, Boiled Without Salt'),
             ('chicken', "'Nduja Chicken, Mozzarella, Slow Roast Tomato Sandwich"),
             ('lunch', 'Lunch out (placeholder)'),
             ('pasta', 'Pasta Carbonara, Bacon'),
@@ -364,10 +371,8 @@ class IngredientSearchRankingApiTestCase(BaseTestCase, ApiBaseTestCase):
         self.assertEqual(self.search_names('餅'), ['餅'])
         self.assertEqual(self.search_names('牛乳'), ['牛乳'])
 
-    def test_short_search_escapes_like_metacharacters(self):
-        for query in ('%', '_', '\\'):
-            with self.subTest(query=query):
-                self.assertEqual(self.search_names(query), [])
+    def test_punctuation_only_search_returns_no_results(self):
+        self.assertEqual(self.search_names('%'), [])
 
     def test_search_finds_a_correctly_spelled_name_from_a_typo(self):
         names = self.search_names('chickn')
@@ -382,5 +387,18 @@ class IngredientSearchRankingApiTestCase(BaseTestCase, ApiBaseTestCase):
     def test_search_ranks_whole_words_above_inside_word_matches(self):
         names = self.search_names('rice')
 
-        self.assert_ranked_before(names, 'Rice', 'Salty Liquorice')
-        self.assert_ranked_before(names, 'Rice Pudding', 'Salty Liquorice')
+        self.assert_ranked_before(
+            names,
+            'Brown rice, long grain, cooked without salt',
+            'Licorice',
+        )
+
+    def test_search_ranks_unicode_case_insensitive_exact_matches_first(self):
+        names = self.search_names('istanbul')
+
+        self.assertEqual(names[:2], ['İstanbul', 'Istanbul spice'])
+
+    def test_search_does_not_rank_generic_substrings_above_fuzzy_matches(self):
+        names = self.search_names('buttr')
+
+        self.assert_ranked_before(names, 'Butter', 'Apple Buttrr Spread')

--- a/wger/nutrition/tests/test_search_api.py
+++ b/wger/nutrition/tests/test_search_api.py
@@ -26,6 +26,7 @@ from rest_framework import status
 # wger
 from wger.core.tests.api_base_test import ApiBaseTestCase
 from wger.core.tests.base_testcase import BaseTestCase
+from wger.nutrition.api.filtersets import _has_literal_trigram
 from wger.nutrition.models import Ingredient
 
 
@@ -281,6 +282,8 @@ class IngredientSearchRankingApiTestCase(BaseTestCase, ApiBaseTestCase):
         'Banana Bread',
         'Salmon',
         'Smoked Salmon',
+        '餅',
+        '牛乳',
     )
 
     @classmethod
@@ -309,6 +312,10 @@ class IngredientSearchRankingApiTestCase(BaseTestCase, ApiBaseTestCase):
         self.assertIn(first, names)
         self.assertIn(second, names)
         self.assertLess(names.index(first), names.index(second))
+
+    def test_substring_search_requires_an_indexable_trigram(self):
+        self.assertFalse(_has_literal_trigram('q--'))
+        self.assertTrue(_has_literal_trigram('jäätelö'))
 
     def test_search_finds_words_in_long_ingredient_names(self):
         cases = (
@@ -350,6 +357,17 @@ class IngredientSearchRankingApiTestCase(BaseTestCase, ApiBaseTestCase):
 
         self.assertIn('Chicken', names)
         self.assertIn('Chickpea Salad', names)
+
+    def test_short_search_only_returns_exact_names(self):
+        self.assertEqual(self.search_names('c'), [])
+        self.assertEqual(self.search_names('ch'), [])
+        self.assertEqual(self.search_names('餅'), ['餅'])
+        self.assertEqual(self.search_names('牛乳'), ['牛乳'])
+
+    def test_short_search_escapes_like_metacharacters(self):
+        for query in ('%', '_', '\\'):
+            with self.subTest(query=query):
+                self.assertEqual(self.search_names(query), [])
 
     def test_search_finds_a_correctly_spelled_name_from_a_typo(self):
         names = self.search_names('chickn')

--- a/wger/utils/db.py
+++ b/wger/utils/db.py
@@ -21,6 +21,7 @@ from django.db import models
 from django.db.models.lookups import (
     Contains,
     Exact,
+    StartsWith,
 )
 
 # wger
@@ -46,6 +47,13 @@ class PostgresILikeContains(Contains):
     Django implements ``icontains`` as ``UPPER(column) LIKE UPPER(value)``, which
     cannot use a trigram index defined on the untransformed column.
     """
+
+    def get_rhs_op(self, connection, rhs):
+        return f'ILIKE {rhs}'
+
+
+class PostgresILikeStartsWith(StartsWith):
+    """Case-insensitive prefix matching using PostgreSQL's native ILIKE operator."""
 
     def get_rhs_op(self, connection, rhs):
         return f'ILIKE {rhs}'

--- a/wger/utils/db.py
+++ b/wger/utils/db.py
@@ -18,9 +18,21 @@ from functools import wraps
 # Django
 from django.conf import settings
 from django.db import models
+from django.db.models.lookups import Contains
 
 # wger
 from wger.utils.uuid import uuid7
+
+
+class PostgresILikeContains(Contains):
+    """Case-insensitive containment using PostgreSQL's native ILIKE operator.
+
+    Django implements ``icontains`` as ``UPPER(column) LIKE UPPER(value)``, which
+    cannot use a trigram index defined on the untransformed column.
+    """
+
+    def get_rhs_op(self, connection, rhs):
+        return f'ILIKE {rhs}'
 
 
 def is_postgres_db():

--- a/wger/utils/db.py
+++ b/wger/utils/db.py
@@ -18,10 +18,26 @@ from functools import wraps
 # Django
 from django.conf import settings
 from django.db import models
-from django.db.models.lookups import Contains
+from django.db.models.lookups import (
+    Contains,
+    Exact,
+)
 
 # wger
 from wger.utils.uuid import uuid7
+
+
+class PostgresILikeExact(Exact):
+    """Case-insensitive equality that can use a plain trigram index."""
+
+    def process_rhs(self, compiler, connection):
+        rhs, params = super().process_rhs(compiler, connection)
+        if params:
+            params = (connection.ops.prep_for_like_query(params[0]), *params[1:])
+        return rhs, params
+
+    def get_rhs_op(self, connection, rhs):
+        return f'ILIKE {rhs}'
 
 
 class PostgresILikeContains(Contains):


### PR DESCRIPTION
<!-- Thank you for contributing! If you want to suggest a new feature, please -->
<!-- discuss it first, either by opening a new issue, asking on an existing   -->
<!-- one, or on discord. -->

# Proposed Changes

- Expand single-term searches with indexable literal substring matches while preserving the existing whole-name trigram candidates for typos.
- Rank exact names, prefixes, and whole-word matches first, then order the remaining candidates by whole-name trigram similarity.
- Bound short and punctuation-only searches to avoid unindexed catalog scans.
- Add PostgreSQL integration tests for long names, multi-word queries, ranking, partial words, typos, Unicode case handling, and short inputs.

This fixes cases where a single search term appears inside a longer ingredient name but falls below the whole-name trigram cutoff, such as `lunch` not finding `Lunch out (placeholder)`.

One- and two-character searches use exact matching. Punctuation-only searches return no results without querying PostgreSQL. Multi-word searches keep the existing trigram candidate path with the improved ranking.

This PR intentionally leaves the optional exact-match toggle out of scope. That requires separate API and client-side UX decisions and can be considered as a follow-up.

## Related Issue(s)

<!-- If applicable, link to any related issues "Closes #123",    -->
<!-- "Closes wger-project/other-repo#123", "See also #123", etc. -->

Related to #2340. This improves name-based search, but personalized ranking and catalog quality remain follow-up work.

Discussed on [Discord](https://discord.com/channels/754275926921052230/1537906071589621781).

## Testing

Run the focused tests in the `dev-postgres` environment:

```bash
docker compose exec web python3 manage.py test \
  wger.nutrition.tests.test_search_api.IngredientSearchRankingApiTestCase
```

All 12 added PostgreSQL integration tests pass. The existing PostgreSQL ingredient search tests also pass.

Query plans and count-plus-top-20 latency were checked against 3,057,932 ingredient names. The indexed paths use the existing trigram GIN index, so no migration is needed. Across 12 common queries, median overhead compared with `main` was about 5%, with higher cost for searches where the literal arm expands recall.


## Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added
- [x] Code has been formatted to avoid unnecessary diffs
- [x] A changelog entry has been added; no manual deployment steps are needed

