### PR TITLE
Support double progression: gate on top of range and require all sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## New features
 
+* Support double progression: progression requirements can now gate against the
+  top of a rep or weight range with `max_repetitions` and `max_weight` rules,
+  and require all prescribed sets to qualify with `"all_sets": true`.
 * Improved openAPI spec. The spec now properly describes the different parts of
   the API and can be used to generate clients.
 

--- a/wger/manager/api/validators.py
+++ b/wger/manager/api/validators.py
@@ -24,6 +24,11 @@ REQUIREMENTS_REQUIRED_KEYS = [
     'rules',
 ]
 
+REQUIREMENTS_ALLOWED_KEYS = [
+    'rules',
+    'all_sets',
+]
+
 
 def validate_requirements(value: dict | None):
     """Validates the requirements field."""
@@ -37,9 +42,16 @@ def validate_requirements(value: dict | None):
     if not all(key in value for key in REQUIREMENTS_REQUIRED_KEYS):
         raise serializers.ValidationError("Missing required keys: 'rules'")
 
+    for key in value:
+        if key not in REQUIREMENTS_ALLOWED_KEYS:
+            raise serializers.ValidationError(f"Unknown key: '{key}'")
+
     if 'rules' in value and not isinstance(value['rules'], list):
         raise serializers.ValidationError("'rules' must be a list.")
 
     for rule in value['rules']:
         if rule not in REQUIREMENTS_RULES_KEYS:
             raise serializers.ValidationError(f'Invalid rule: {rule}')
+
+    if 'all_sets' in value and not isinstance(value['all_sets'], bool):
+        raise serializers.ValidationError("'all_sets' must be a boolean.")

--- a/wger/manager/consts.py
+++ b/wger/manager/consts.py
@@ -21,8 +21,16 @@ REQUIREMENTS_RULES_KEYS = [
     'repetitions',
     'rir',
     'rest',
+    'max_repetitions',
+    'max_weight',
 ]
 """Log fields that progression requirements can reference"""
+
+REQUIREMENTS_MAX_RULES = {
+    'max_repetitions': 'repetitions',
+    'max_weight': 'weight',
+}
+"""Maps max requirement rules to the log field they read from"""
 
 REP_UNIT_REPETITIONS = 1
 REP_UNIT_TILL_FAILURE = 2

--- a/wger/manager/dataclasses.py
+++ b/wger/manager/dataclasses.py
@@ -270,9 +270,11 @@ def round_value(
 @dataclass(init=False)
 class ConfigRequirements:
     rules: List[str] = field(default_factory=list)
+    all_sets: bool = False
 
     def __init__(self, data: Dict[str, Any]):
         self.rules = data.get('rules', [])
+        self.all_sets = data.get('all_sets', False)
 
     def __bool__(self):
         return bool(self.rules)

--- a/wger/manager/models/slot_entry.py
+++ b/wger/manager/models/slot_entry.py
@@ -35,6 +35,7 @@ from wger.core.models import (
 from wger.exercises.models import Exercise
 from wger.manager.consts import (
     REP_UNIT_REPETITIONS,
+    REQUIREMENTS_MAX_RULES,
     REQUIREMENTS_RULES_KEYS,
     WEIGHT_UNIT_KG,
 )
@@ -98,6 +99,16 @@ BASE_FIELD = {
     'maxsets': 'sets',
 }
 """Maps max fields to their base field, both advance together"""
+
+RULE_FIELD_MAP = {
+    'weight': 'weight',
+    'repetitions': 'repetitions',
+    'rir': 'rir',
+    'rest': 'rest',
+    'max_repetitions': 'maxrepetitions',
+    'max_weight': 'maxweight',
+}
+"""Maps requirement rule names to their progression field in _WalkState"""
 
 FIELD_CAPS = {
     field: MAX_COMPOUND_RIR if field in ('rir', 'maxrir') else MAX_COMPOUND_VALUE
@@ -352,19 +363,44 @@ class SlotEntry(models.Model):
         """Rounding applied to a field for display and requirement thresholds"""
         return {
             'weight': self.weight_rounding,
+            'max_weight': self.weight_rounding,
+            'maxweight': self.weight_rounding,
             'repetitions': self.repetition_rounding,
+            'max_repetitions': self.repetition_rounding,
+            'maxrepetitions': self.repetition_rounding,
             'rir': Decimal('0.5'),
             'rest': 1,
         }.get(field)
 
     @staticmethod
-    def _requirements_met(requirements, log_data: List[WorkoutLog], thresholds: dict) -> bool:
-        """True if any single log reaches the thresholds of all required fields"""
+    def _requirements_met(
+        requirements,
+        log_data: List[WorkoutLog],
+        thresholds: dict,
+        prescribed_sets: int = 1,
+    ) -> bool:
+        """
+        True if the logs meet the requirements thresholds.
+
+        If requirements.all_sets is True, at least `prescribed_sets` (floored at 1)
+        must be logged and every logged set must qualify. Otherwise, any single
+        qualifying set is sufficient.
+        """
 
         def rule_met(log: WorkoutLog, rule: str) -> bool:
-            log_value = getattr(log, rule, None)
+            log_field = REQUIREMENTS_MAX_RULES.get(rule, rule)
+            log_value = getattr(log, log_field, None)
             threshold = thresholds.get(rule)
             return log_value is not None and threshold is not None and log_value >= threshold
+
+        if not requirements.rules:
+            return True
+
+        if getattr(requirements, 'all_sets', False):
+            min_sets = max(prescribed_sets, 1)
+            if len(log_data) < min_sets:
+                return False
+            return all(all(rule_met(log, rule) for rule in requirements.rules) for log in log_data)
 
         return any(all(rule_met(log, rule) for rule in requirements.rules) for log in log_data)
 
@@ -436,9 +472,13 @@ class SlotEntry(models.Model):
         for i in range(1, target + 1):
             # Thresholds are the displayed prescriptions of the previous iteration
             thresholds = {
-                rule: round_value(states[rule].value, self._display_rounding(rule))
+                rule: round_value(
+                    states[RULE_FIELD_MAP[rule]].value,
+                    self._display_rounding(rule),
+                )
                 for rule in REQUIREMENTS_RULES_KEYS
             }
+            prescribed_sets = max(int(states['sets'].value or 1), 1)
             log_data = logs_by_iteration.get(i - 1, [])
 
             # All fields advance first, the gates below read the candidates
@@ -464,7 +504,7 @@ class SlotEntry(models.Model):
                 is_open = (
                     i == 1
                     or not requirements
-                    or self._requirements_met(requirements, log_data, thresholds)
+                    or self._requirements_met(requirements, log_data, thresholds, prescribed_sets)
                 )
                 states[field].apply(candidate, is_open, FIELD_CAPS[field])
 

--- a/wger/manager/tests/test_api_validators.py
+++ b/wger/manager/tests/test_api_validators.py
@@ -1,0 +1,104 @@
+# This file is part of wger Workout Manager.
+#
+# wger Workout Manager is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# wger Workout Manager is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Workout Manager.  If not, see <http://www.gnu.org/licenses/>.
+
+# Third Party
+from rest_framework import serializers
+
+# wger
+from wger.core.tests.base_testcase import WgerTestCase
+from wger.manager.api.validators import validate_requirements
+
+
+class ValidateRequirementsTestCase(WgerTestCase):
+    """
+    Test suite for validate_requirements function
+    """
+
+    def test_valid_requirements(self):
+        """Test valid requirement structures pass without errors"""
+        # None is allowed
+        self.assertIsNone(validate_requirements(None))
+
+        # Basic rules
+        self.assertIsNone(validate_requirements({'rules': ['weight']}))
+        self.assertIsNone(validate_requirements({'rules': ['repetitions']}))
+        self.assertIsNone(validate_requirements({'rules': ['rir']}))
+        self.assertIsNone(validate_requirements({'rules': ['rest']}))
+
+        # New max rules
+        self.assertIsNone(validate_requirements({'rules': ['max_repetitions']}))
+        self.assertIsNone(validate_requirements({'rules': ['max_weight']}))
+        self.assertIsNone(validate_requirements({'rules': ['max_repetitions', 'weight']}))
+
+        # With all_sets flag
+        self.assertIsNone(validate_requirements({'rules': ['max_repetitions'], 'all_sets': True}))
+        self.assertIsNone(validate_requirements({'rules': ['max_repetitions'], 'all_sets': False}))
+
+        # Empty rules list
+        self.assertIsNone(validate_requirements({'rules': []}))
+
+    def test_invalid_type(self):
+        """Test that non-dict value raises ValidationError"""
+        with self.assertRaises(serializers.ValidationError):
+            validate_requirements('not a dict')
+
+        with self.assertRaises(serializers.ValidationError):
+            validate_requirements(['rules'])
+
+        with self.assertRaises(serializers.ValidationError):
+            validate_requirements(123)
+
+    def test_missing_required_rules_key(self):
+        """Test that missing 'rules' key raises ValidationError"""
+        with self.assertRaises(serializers.ValidationError):
+            validate_requirements({})
+
+        with self.assertRaises(serializers.ValidationError):
+            validate_requirements({'all_sets': True})
+
+    def test_invalid_rules_type(self):
+        """Test that non-list 'rules' raises ValidationError"""
+        with self.assertRaises(serializers.ValidationError):
+            validate_requirements({'rules': 'repetitions'})
+
+        with self.assertRaises(serializers.ValidationError):
+            validate_requirements({'rules': {'repetitions': True}})
+
+    def test_invalid_rule_name(self):
+        """Test that invalid rule names are rejected"""
+        with self.assertRaises(serializers.ValidationError):
+            validate_requirements({'rules': ['invalid_rule']})
+
+        with self.assertRaises(serializers.ValidationError):
+            validate_requirements({'rules': ['repetitions', 'foo_bar']})
+
+    def test_unknown_keys_rejected(self):
+        """Test that unexpected keys in the requirements dict are rejected"""
+        with self.assertRaises(serializers.ValidationError):
+            validate_requirements({'rules': ['repetitions'], 'unknown_key': 123})
+
+        with self.assertRaises(serializers.ValidationError):
+            validate_requirements({'rules': ['repetitions'], 'extra': 'data'})
+
+    def test_invalid_all_sets_type(self):
+        """Test that non-boolean all_sets values are rejected"""
+        with self.assertRaises(serializers.ValidationError):
+            validate_requirements({'rules': ['max_repetitions'], 'all_sets': 'true'})
+
+        with self.assertRaises(serializers.ValidationError):
+            validate_requirements({'rules': ['max_repetitions'], 'all_sets': 1})
+
+        with self.assertRaises(serializers.ValidationError):
+            validate_requirements({'rules': ['max_repetitions'], 'all_sets': None})

--- a/wger/manager/tests/test_change_config_model.py
+++ b/wger/manager/tests/test_change_config_model.py
@@ -61,3 +61,16 @@ class ChangeConfigTestCase(WgerTestCase):
         config.requirements = {'rules': ['weight', 'repetitions']}
 
         self.assertTrue(config.requirements_object)
+
+    def test_requirements_all_sets_flag(self):
+        """
+        Test that all_sets is parsed and defaults to False
+        """
+        config_default = SetsConfig(requirements={'rules': ['max_repetitions']})
+        self.assertFalse(config_default.requirements_object.all_sets)
+
+        config_true = SetsConfig(requirements={'rules': ['max_repetitions'], 'all_sets': True})
+        self.assertTrue(config_true.requirements_object.all_sets)
+
+        config_false = SetsConfig(requirements={'rules': ['max_repetitions'], 'all_sets': False})
+        self.assertFalse(config_false.requirements_object.all_sets)

--- a/wger/manager/tests/test_slot_entry.py
+++ b/wger/manager/tests/test_slot_entry.py
@@ -1216,6 +1216,352 @@ class SlotEntryTestCase(WgerTestCase):
         # Iteration 3 must reflect the config, not the cached iteration-1 result
         self.assertEqual(self.slot_entry.get_config_data(3).weight, Decimal(100))
 
+    def test_requirements_max_repetitions_rule(self):
+        """
+        max_repetitions rule gates against the top of the rep range, not the bottom
+        """
+        self.slot_entry.weight_rounding = 2.5
+        self.slot_entry.repetition_rounding = 1
+        self.slot_entry.save()
+
+        RepetitionsConfig(slot_entry=self.slot_entry, iteration=1, value=8).save()
+        MaxRepetitionsConfig(slot_entry=self.slot_entry, iteration=1, value=12).save()
+        WeightConfig(slot_entry=self.slot_entry, iteration=1, value=60).save()
+        WeightConfig(
+            slot_entry=self.slot_entry,
+            iteration=2,
+            value=2.5,
+            operation=OperationChoices.PLUS,
+            step=StepChoices.ABSOLUTE,
+            repeat=True,
+            requirements={'rules': ['max_repetitions']},
+        ).save()
+
+        # Logging bottom of range (8 reps) does NOT meet max_repetitions threshold (12)
+        self._log_repetitions(iteration=1, repetitions=8, weight=60)
+        self.assertEqual(self.slot_entry.get_config_data(2).weight, Decimal(60))
+
+        # Logging top of range (12 reps) meets max_repetitions threshold
+        self._log_repetitions(iteration=2, repetitions=12, weight=60)
+        self.assertEqual(self.slot_entry.get_config_data(3).weight, Decimal('62.5'))
+
+    def test_requirements_max_weight_rule(self):
+        """
+        max_weight rule gates against the top of the weight range, not the bottom
+        """
+        self.slot_entry.weight_rounding = 2.5
+        self.slot_entry.repetition_rounding = 1
+        self.slot_entry.save()
+
+        WeightConfig(slot_entry=self.slot_entry, iteration=1, value=80).save()
+        MaxWeightConfig(slot_entry=self.slot_entry, iteration=1, value=100).save()
+        RepetitionsConfig(slot_entry=self.slot_entry, iteration=1, value=5).save()
+        RepetitionsConfig(
+            slot_entry=self.slot_entry,
+            iteration=2,
+            value=1,
+            operation=OperationChoices.PLUS,
+            step=StepChoices.ABSOLUTE,
+            repeat=True,
+            requirements={'rules': ['max_weight']},
+        ).save()
+
+        # Logging bottom of weight range (80kg) does NOT meet max_weight threshold (100kg)
+        self._log_repetitions(iteration=1, repetitions=5, weight=80)
+        self.assertEqual(self.slot_entry.get_config_data(2).repetitions, Decimal(5))
+
+        # Logging top of weight range (100kg) meets max_weight threshold
+        self._log_repetitions(iteration=2, repetitions=5, weight=100)
+        self.assertEqual(self.slot_entry.get_config_data(3).repetitions, Decimal(6))
+
+    def test_requirements_all_sets_partial_qualification_does_not_advance(self):
+        """
+        When all_sets is True, all logged sets must meet the requirement
+        """
+        self.slot_entry.weight_rounding = 2.5
+        self.slot_entry.repetition_rounding = 1
+        self.slot_entry.save()
+
+        SetsConfig(slot_entry=self.slot_entry, iteration=1, value=3).save()
+        RepetitionsConfig(slot_entry=self.slot_entry, iteration=1, value=8).save()
+        MaxRepetitionsConfig(slot_entry=self.slot_entry, iteration=1, value=12).save()
+        WeightConfig(slot_entry=self.slot_entry, iteration=1, value=60).save()
+        WeightConfig(
+            slot_entry=self.slot_entry,
+            iteration=2,
+            value=2.5,
+            operation=OperationChoices.PLUS,
+            step=StepChoices.ABSOLUTE,
+            repeat=True,
+            requirements={'rules': ['max_repetitions'], 'all_sets': True},
+        ).save()
+
+        # 3 sets logged: 12, 12, 10 -> not all sets reached 12 reps
+        self._log_repetitions(iteration=1, repetitions=12, weight=60)
+        self._log_repetitions(iteration=1, repetitions=12, weight=60)
+        self._log_repetitions(iteration=1, repetitions=10, weight=60)
+
+        self.assertEqual(self.slot_entry.get_config_data(2).weight, Decimal(60))
+
+    def test_requirements_all_sets_under_logged_does_not_advance(self):
+        """
+        When all_sets is True, logging fewer than prescribed sets does not qualify
+        """
+        self.slot_entry.weight_rounding = 2.5
+        self.slot_entry.repetition_rounding = 1
+        self.slot_entry.save()
+
+        SetsConfig(slot_entry=self.slot_entry, iteration=1, value=3).save()
+        RepetitionsConfig(slot_entry=self.slot_entry, iteration=1, value=8).save()
+        MaxRepetitionsConfig(slot_entry=self.slot_entry, iteration=1, value=12).save()
+        WeightConfig(slot_entry=self.slot_entry, iteration=1, value=60).save()
+        WeightConfig(
+            slot_entry=self.slot_entry,
+            iteration=2,
+            value=2.5,
+            operation=OperationChoices.PLUS,
+            step=StepChoices.ABSOLUTE,
+            repeat=True,
+            requirements={'rules': ['max_repetitions'], 'all_sets': True},
+        ).save()
+
+        # Only 2 sets logged (3 prescribed), even though both hit 12 reps
+        self._log_repetitions(iteration=1, repetitions=12, weight=60)
+        self._log_repetitions(iteration=1, repetitions=12, weight=60)
+
+        self.assertEqual(self.slot_entry.get_config_data(2).weight, Decimal(60))
+
+    def test_requirements_all_sets_empty_logs_does_not_advance(self):
+        """
+        When all_sets is True and no logs exist, requirements are not met vacuously
+        """
+        self.slot_entry.weight_rounding = 2.5
+        self.slot_entry.save()
+
+        SetsConfig(slot_entry=self.slot_entry, iteration=1, value=3).save()
+        RepetitionsConfig(slot_entry=self.slot_entry, iteration=1, value=8).save()
+        MaxRepetitionsConfig(slot_entry=self.slot_entry, iteration=1, value=12).save()
+        WeightConfig(slot_entry=self.slot_entry, iteration=1, value=60).save()
+        WeightConfig(
+            slot_entry=self.slot_entry,
+            iteration=2,
+            value=2.5,
+            operation=OperationChoices.PLUS,
+            step=StepChoices.ABSOLUTE,
+            repeat=True,
+            requirements={'rules': ['max_repetitions'], 'all_sets': True},
+        ).save()
+
+        # No logs for iteration 1
+        self.assertEqual(self.slot_entry.get_config_data(2).weight, Decimal(60))
+
+    def test_requirements_all_sets_full_qualification_advances(self):
+        """
+        When all_sets is True and all prescribed sets meet thresholds, progression advances
+        """
+        self.slot_entry.weight_rounding = 2.5
+        self.slot_entry.repetition_rounding = 1
+        self.slot_entry.save()
+
+        SetsConfig(slot_entry=self.slot_entry, iteration=1, value=3).save()
+        RepetitionsConfig(slot_entry=self.slot_entry, iteration=1, value=8).save()
+        MaxRepetitionsConfig(slot_entry=self.slot_entry, iteration=1, value=12).save()
+        WeightConfig(slot_entry=self.slot_entry, iteration=1, value=60).save()
+        WeightConfig(
+            slot_entry=self.slot_entry,
+            iteration=2,
+            value=2.5,
+            operation=OperationChoices.PLUS,
+            step=StepChoices.ABSOLUTE,
+            repeat=True,
+            requirements={'rules': ['max_repetitions'], 'all_sets': True},
+        ).save()
+
+        # 3 sets logged, all meeting 12 reps
+        self._log_repetitions(iteration=1, repetitions=12, weight=60)
+        self._log_repetitions(iteration=1, repetitions=12, weight=60)
+        self._log_repetitions(iteration=1, repetitions=12, weight=60)
+
+        self.assertEqual(self.slot_entry.get_config_data(2).weight, Decimal('62.5'))
+
+    def test_requirements_all_sets_extra_qualifying_sets_advance(self):
+        """
+        When all_sets is True and more sets than prescribed are logged, all must qualify
+        """
+        self.slot_entry.weight_rounding = 2.5
+        self.slot_entry.repetition_rounding = 1
+        self.slot_entry.save()
+
+        SetsConfig(slot_entry=self.slot_entry, iteration=1, value=3).save()
+        RepetitionsConfig(slot_entry=self.slot_entry, iteration=1, value=8).save()
+        MaxRepetitionsConfig(slot_entry=self.slot_entry, iteration=1, value=12).save()
+        WeightConfig(slot_entry=self.slot_entry, iteration=1, value=60).save()
+        WeightConfig(
+            slot_entry=self.slot_entry,
+            iteration=2,
+            value=2.5,
+            operation=OperationChoices.PLUS,
+            step=StepChoices.ABSOLUTE,
+            repeat=True,
+            requirements={'rules': ['max_repetitions'], 'all_sets': True},
+        ).save()
+
+        # 4 sets logged (3 prescribed), all 4 qualifying
+        self._log_repetitions(iteration=1, repetitions=12, weight=60)
+        self._log_repetitions(iteration=1, repetitions=12, weight=60)
+        self._log_repetitions(iteration=1, repetitions=13, weight=60)
+        self._log_repetitions(iteration=1, repetitions=12, weight=60)
+
+        self.assertEqual(self.slot_entry.get_config_data(2).weight, Decimal('62.5'))
+
+    def test_requirements_all_sets_extra_sets_with_one_failing_does_not_advance(self):
+        """
+        When all_sets is True and extra sets are logged, even 1 failing set prevents advancement
+        """
+        self.slot_entry.weight_rounding = 2.5
+        self.slot_entry.repetition_rounding = 1
+        self.slot_entry.save()
+
+        SetsConfig(slot_entry=self.slot_entry, iteration=1, value=3).save()
+        RepetitionsConfig(slot_entry=self.slot_entry, iteration=1, value=8).save()
+        MaxRepetitionsConfig(slot_entry=self.slot_entry, iteration=1, value=12).save()
+        WeightConfig(slot_entry=self.slot_entry, iteration=1, value=60).save()
+        WeightConfig(
+            slot_entry=self.slot_entry,
+            iteration=2,
+            value=2.5,
+            operation=OperationChoices.PLUS,
+            step=StepChoices.ABSOLUTE,
+            repeat=True,
+            requirements={'rules': ['max_repetitions'], 'all_sets': True},
+        ).save()
+
+        # 4 sets logged: first 3 qualify, 4th fails
+        self._log_repetitions(iteration=1, repetitions=12, weight=60)
+        self._log_repetitions(iteration=1, repetitions=12, weight=60)
+        self._log_repetitions(iteration=1, repetitions=12, weight=60)
+        self._log_repetitions(iteration=1, repetitions=8, weight=60)
+
+        self.assertEqual(self.slot_entry.get_config_data(2).weight, Decimal(60))
+
+    def test_requirements_all_sets_false_single_qualifying_set_advances(self):
+        """
+        When all_sets is False (default), a single qualifying set is sufficient
+        """
+        self.slot_entry.weight_rounding = 2.5
+        self.slot_entry.repetition_rounding = 1
+        self.slot_entry.save()
+
+        SetsConfig(slot_entry=self.slot_entry, iteration=1, value=3).save()
+        RepetitionsConfig(slot_entry=self.slot_entry, iteration=1, value=8).save()
+        MaxRepetitionsConfig(slot_entry=self.slot_entry, iteration=1, value=12).save()
+        WeightConfig(slot_entry=self.slot_entry, iteration=1, value=60).save()
+        WeightConfig(
+            slot_entry=self.slot_entry,
+            iteration=2,
+            value=2.5,
+            operation=OperationChoices.PLUS,
+            step=StepChoices.ABSOLUTE,
+            repeat=True,
+            requirements={'rules': ['max_repetitions'], 'all_sets': False},
+        ).save()
+
+        # 3 sets logged: only 1 hits 12 reps
+        self._log_repetitions(iteration=1, repetitions=12, weight=60)
+        self._log_repetitions(iteration=1, repetitions=10, weight=60)
+        self._log_repetitions(iteration=1, repetitions=8, weight=60)
+
+        self.assertEqual(self.slot_entry.get_config_data(2).weight, Decimal('62.5'))
+
+    def test_requirements_classic_double_progression_lifecycle(self):
+        """
+        Full lifecycle of double progression across multiple workouts
+        """
+        self.slot_entry.weight_rounding = 2.5
+        self.slot_entry.repetition_rounding = 1
+        self.slot_entry.save()
+
+        SetsConfig(slot_entry=self.slot_entry, iteration=1, value=3).save()
+        RepetitionsConfig(slot_entry=self.slot_entry, iteration=1, value=8).save()
+        MaxRepetitionsConfig(slot_entry=self.slot_entry, iteration=1, value=12).save()
+        WeightConfig(slot_entry=self.slot_entry, iteration=1, value=60).save()
+        WeightConfig(
+            slot_entry=self.slot_entry,
+            iteration=2,
+            value=2.5,
+            operation=OperationChoices.PLUS,
+            step=StepChoices.ABSOLUTE,
+            repeat=True,
+            requirements={'rules': ['max_repetitions'], 'all_sets': True},
+        ).save()
+
+        # Workout 1: 8, 8, 8 -> stays 60kg
+        self._log_repetitions(iteration=1, repetitions=8, weight=60)
+        self._log_repetitions(iteration=1, repetitions=8, weight=60)
+        self._log_repetitions(iteration=1, repetitions=8, weight=60)
+        self.assertEqual(self.slot_entry.get_config_data(2).weight, Decimal(60))
+
+        # Workout 2: 10, 10, 9 -> stays 60kg
+        self._log_repetitions(iteration=2, repetitions=10, weight=60)
+        self._log_repetitions(iteration=2, repetitions=10, weight=60)
+        self._log_repetitions(iteration=2, repetitions=9, weight=60)
+        self.assertEqual(self.slot_entry.get_config_data(3).weight, Decimal(60))
+
+        # Workout 3: 12, 12, 11 -> stays 60kg
+        self._log_repetitions(iteration=3, repetitions=12, weight=60)
+        self._log_repetitions(iteration=3, repetitions=12, weight=60)
+        self._log_repetitions(iteration=3, repetitions=11, weight=60)
+        self.assertEqual(self.slot_entry.get_config_data(4).weight, Decimal(60))
+
+        # Workout 4: 12, 12, 12 -> all sets hit top of range! Advances to 62.5kg
+        self._log_repetitions(iteration=4, repetitions=12, weight=60)
+        self._log_repetitions(iteration=4, repetitions=12, weight=60)
+        self._log_repetitions(iteration=4, repetitions=12, weight=60)
+        self.assertEqual(self.slot_entry.get_config_data(5).weight, Decimal('62.5'))
+
+        # Workout 5: drop back to bottom of range at new weight (8, 8, 8 @ 62.5kg) -> stays 62.5kg
+        self._log_repetitions(iteration=5, repetitions=8, weight=Decimal('62.5'))
+        self._log_repetitions(iteration=5, repetitions=8, weight=Decimal('62.5'))
+        self._log_repetitions(iteration=5, repetitions=8, weight=Decimal('62.5'))
+        self.assertEqual(self.slot_entry.get_config_data(6).weight, Decimal('62.5'))
+
+    def test_requirements_all_sets_multiple_rules(self):
+        """
+        When all_sets is True with multiple rules, every set must meet every rule
+        """
+        self.slot_entry.weight_rounding = 2.5
+        self.slot_entry.repetition_rounding = 1
+        self.slot_entry.save()
+
+        SetsConfig(slot_entry=self.slot_entry, iteration=1, value=3).save()
+        RepetitionsConfig(slot_entry=self.slot_entry, iteration=1, value=8).save()
+        MaxRepetitionsConfig(slot_entry=self.slot_entry, iteration=1, value=12).save()
+        WeightConfig(slot_entry=self.slot_entry, iteration=1, value=60).save()
+        WeightConfig(
+            slot_entry=self.slot_entry,
+            iteration=2,
+            value=2.5,
+            operation=OperationChoices.PLUS,
+            step=StepChoices.ABSOLUTE,
+            repeat=True,
+            requirements={'rules': ['max_repetitions', 'weight'], 'all_sets': True},
+        ).save()
+
+        # Set 1 meets both (12 reps, 60kg), Set 2 fails weight (12 reps, 55kg),
+        # Set 3 meets both (12 reps, 60kg)
+        self._log_repetitions(iteration=1, repetitions=12, weight=60)
+        self._log_repetitions(iteration=1, repetitions=12, weight=55)
+        self._log_repetitions(iteration=1, repetitions=12, weight=60)
+
+        self.assertEqual(self.slot_entry.get_config_data(2).weight, Decimal(60))
+
+        # Iteration 2: all 3 sets meet both rules
+        self._log_repetitions(iteration=2, repetitions=12, weight=60)
+        self._log_repetitions(iteration=2, repetitions=12, weight=60)
+        self._log_repetitions(iteration=2, repetitions=12, weight=60)
+
+        self.assertEqual(self.slot_entry.get_config_data(3).weight, Decimal('62.5'))
+
 
 class WalkConfigValuesTestCase(SimpleTestCase):
     """


### PR DESCRIPTION
# Proposed Changes

Support classic double progression in the progression requirements engine:

1. **New `max_repetitions` and `max_weight` rules**: Read the same log field as their base rule (`repetitions`, `weight`) but gate against the top (ceiling) of the prescribed range (`states['maxrepetitions']` / `states['maxweight']`) rather than the bottom.
2. **New `all_sets` boolean flag**: When `true`, requires at least the prescribed number of sets to be logged and every logged set to satisfy all rules (rather than a single qualifying set being sufficient).
3. **API Validator support**: Validates that `all_sets` is boolean and rejects unknown keys in the requirements dictionary.
4. **Comprehensive regression tests**: Added tests covering `max_repetitions`, `max_weight`, under-logging, empty logs, partial qualification, extra sets, full double progression lifecycles, and API validation.

## Related Issue(s)

Closes #2480

## Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code has been formatted to avoid unnecessary diffs (`ruff format && isort .`)
- [x] If the feature is big enough or if there are manual steps needed (deployment changes etc.), write a small writeup in `CHANGELOG.md`