### PR TITLE
Pre-select routine weight units from the user profile (#2205)

### DIFF
--- a/wger/manager/api/serializers.py
+++ b/wger/manager/api/serializers.py
@@ -17,6 +17,7 @@
 import datetime
 
 # Django
+from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.utils import timezone
 
@@ -28,6 +29,10 @@ from wger.core.models import UserProfile
 from wger.manager.api.consts import BASE_CONFIG_FIELDS
 from wger.manager.api.fields import DecimalOrIntegerField
 from wger.manager.api.validators import validate_requirements
+from wger.manager.consts import (
+    WEIGHT_UNIT_KG,
+    WEIGHT_UNIT_LB,
+)
 from wger.manager.models import (
     Day,
     MaxRepetitionsConfig,
@@ -46,6 +51,42 @@ from wger.manager.models import (
     WorkoutLog,
     WorkoutSession,
 )
+
+
+def profile_weight_unit_id(profile) -> int:
+    """Map a user profile's kg/lb preference to the WeightUnit PK used by routines."""
+    return WEIGHT_UNIT_KG if profile.use_metric else WEIGHT_UNIT_LB
+
+
+def apply_profile_weight_unit(serializer, validated_data, profile) -> None:
+    """
+    Default weight_unit from the profile when the client omitted it.
+
+    The model default is kg, so ``validated_data`` always has a unit after
+    validation. Inspect ``initial_data`` so an explicit kg/lb (or null) is
+    kept. Used only from ``create()`` so PATCH/edits do not clobber stored
+    units if the profile later changes.
+    """
+    initial = getattr(serializer, 'initial_data', None)
+    if initial is not None and 'weight_unit' in initial:
+        return
+    if profile is None:
+        return
+
+    validated_data.pop('weight_unit', None)
+    validated_data['weight_unit_id'] = profile_weight_unit_id(profile)
+
+
+def _user_from_validated_data(validated_data, serializer):
+    """Resolve the owning user from create() kwargs, then the request."""
+    user = validated_data.get('user')
+    if user is None and validated_data.get('user_id') is not None:
+        user = User.objects.filter(pk=validated_data['user_id']).first()
+    if user is None:
+        request = serializer.context.get('request')
+        if request is not None and getattr(request.user, 'is_authenticated', False):
+            user = request.user
+    return user
 
 
 class RoutineSerializer(serializers.ModelSerializer):
@@ -361,6 +402,12 @@ class SlotEntrySerializer(serializers.ModelSerializer):
             'config',
         )
 
+    def create(self, validated_data):
+        slot = validated_data.get('slot')
+        profile = slot.day.routine.user.userprofile if slot is not None else None
+        apply_profile_weight_unit(self, validated_data, profile)
+        return super().create(validated_data)
+
 
 class SetConfigDataSerializer(serializers.Serializer):
     """
@@ -599,6 +646,12 @@ class WorkoutLogSerializer(serializers.ModelSerializer):
             'rest',
             'rest_target',
         )
+
+    def create(self, validated_data):
+        user = _user_from_validated_data(validated_data, self)
+        profile = getattr(user, 'userprofile', None)
+        apply_profile_weight_unit(self, validated_data, profile)
+        return super().create(validated_data)
 
 
 class LogDisplaySerializer(serializers.Serializer):

--- a/wger/manager/tests/test_api_weight_unit_default.py
+++ b/wger/manager/tests/test_api_weight_unit_default.py
@@ -1,0 +1,186 @@
+# This file is part of wger Workout Manager.
+#
+# wger Workout Manager is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# wger Workout Manager is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Workout Manager.  If not, see <http://www.gnu.org/licenses/>.
+
+# Django
+from django.contrib.auth.models import User
+from django.urls import reverse
+
+# Third Party
+from rest_framework import status
+
+# wger
+from wger.core.tests.base_testcase import WgerTestCase
+from wger.manager.consts import (
+    WEIGHT_UNIT_KG,
+    WEIGHT_UNIT_LB,
+)
+from wger.manager.models import (
+    SlotEntry,
+    WorkoutLog,
+)
+
+
+class SlotEntryWeightUnitDefaultTestCase(WgerTestCase):
+    """
+    New slot entries pre-select the routine owner's profile weight unit.
+
+    Fixture: slot pk=1 belongs to admin's routine. Admin's profile defaults to kg.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user_login('admin')
+        self.profile = User.objects.get(username='admin').userprofile
+
+    def _set_profile_unit(self, unit: str):
+        self.profile.weight_unit = unit
+        self.profile.save()
+
+    def _create_entry(self, **extra):
+        payload = {
+            'slot': 1,
+            'exercise': 1,
+        }
+        payload.update(extra)
+        return self.client.post(
+            reverse('slot-entry-list'),
+            data=payload,
+            content_type='application/json',
+        )
+
+    def test_new_entry_uses_profile_kg(self):
+        self._set_profile_unit('kg')
+
+        response = self._create_entry()
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+
+        entry = SlotEntry.objects.get(pk=response.data['id'])
+        self.assertEqual(entry.weight_unit_id, WEIGHT_UNIT_KG)
+
+    def test_new_entry_uses_profile_lb(self):
+        self._set_profile_unit('lb')
+
+        response = self._create_entry()
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+
+        entry = SlotEntry.objects.get(pk=response.data['id'])
+        self.assertEqual(entry.weight_unit_id, WEIGHT_UNIT_LB)
+
+    def test_explicit_unit_overrides_profile(self):
+        self._set_profile_unit('lb')
+
+        response = self._create_entry(weight_unit=WEIGHT_UNIT_KG)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+
+        entry = SlotEntry.objects.get(pk=response.data['id'])
+        self.assertEqual(entry.weight_unit_id, WEIGHT_UNIT_KG)
+
+    def test_edit_preserves_stored_unit_after_profile_change(self):
+        self._set_profile_unit('kg')
+        create = self._create_entry()
+        self.assertEqual(create.status_code, status.HTTP_201_CREATED, create.content)
+        entry_id = create.data['id']
+        self.assertEqual(SlotEntry.objects.get(pk=entry_id).weight_unit_id, WEIGHT_UNIT_KG)
+
+        self._set_profile_unit('lb')
+        response = self.client.patch(
+            reverse('slot-entry-detail', kwargs={'pk': entry_id}),
+            data={'comment': 'keep unit'},
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.assertEqual(SlotEntry.objects.get(pk=entry_id).weight_unit_id, WEIGHT_UNIT_KG)
+
+    def test_profile_change_only_affects_new_entries(self):
+        self._set_profile_unit('lb')
+        first = self._create_entry()
+        self.assertEqual(first.status_code, status.HTTP_201_CREATED, first.content)
+        first_id = first.data['id']
+        self.assertEqual(SlotEntry.objects.get(pk=first_id).weight_unit_id, WEIGHT_UNIT_LB)
+
+        self._set_profile_unit('kg')
+        second = self._create_entry()
+        self.assertEqual(second.status_code, status.HTTP_201_CREATED, second.content)
+
+        self.assertEqual(SlotEntry.objects.get(pk=first_id).weight_unit_id, WEIGHT_UNIT_LB)
+        self.assertEqual(SlotEntry.objects.get(pk=second.data['id']).weight_unit_id, WEIGHT_UNIT_KG)
+
+
+class WorkoutLogWeightUnitDefaultTestCase(WgerTestCase):
+    """
+    New workout logs pre-select the user's profile weight unit.
+
+    Fixture: slot_entry pk=1 and routine pk=1 belong to admin.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user_login('admin')
+        self.profile = User.objects.get(username='admin').userprofile
+
+    def _set_profile_unit(self, unit: str):
+        self.profile.weight_unit = unit
+        self.profile.save()
+
+    def _create_log(self, **extra):
+        payload = {
+            'routine': 1,
+            'slot_entry': 1,
+            'exercise': 1,
+            'repetitions': 10,
+            'repetitions_unit': 1,
+            'weight': 100,
+            'date': '2024-01-01',
+        }
+        payload.update(extra)
+        return self.client.post(
+            reverse('workoutlog-list'),
+            data=payload,
+            content_type='application/json',
+        )
+
+    def test_new_log_uses_profile_lb(self):
+        self._set_profile_unit('lb')
+
+        response = self._create_log()
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+
+        log = WorkoutLog.objects.get(pk=response.data['id'])
+        self.assertEqual(log.weight_unit_id, WEIGHT_UNIT_LB)
+
+    def test_explicit_unit_overrides_profile(self):
+        self._set_profile_unit('lb')
+
+        response = self._create_log(weight_unit=WEIGHT_UNIT_KG)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+
+        log = WorkoutLog.objects.get(pk=response.data['id'])
+        self.assertEqual(log.weight_unit_id, WEIGHT_UNIT_KG)
+
+    def test_edit_preserves_stored_unit_after_profile_change(self):
+        self._set_profile_unit('kg')
+        create = self._create_log()
+        self.assertEqual(create.status_code, status.HTTP_201_CREATED, create.content)
+        log_id = create.data['id']
+        self.assertEqual(WorkoutLog.objects.get(pk=log_id).weight_unit_id, WEIGHT_UNIT_KG)
+
+        self._set_profile_unit('lb')
+        response = self.client.patch(
+            reverse('workoutlog-detail', kwargs={'pk': log_id}),
+            data={'weight': 101},
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.assertEqual(WorkoutLog.objects.get(pk=log_id).weight_unit_id, WEIGHT_UNIT_KG)


### PR DESCRIPTION
# Proposed Changes

When creating a `SlotEntry` or `WorkoutLog` without an explicit `weight_unit`, the API always stored kilograms because that is the model default. Users who set `weight_unit` to `lb` on their profile still got kg on new routine entries.

This PR defaults the unit from the owner's profile **only on create**:

- New slot entries use the **routine owner's** profile (`kg` → unit 1, `lb` → unit 2).
- New workout logs use the **log owner's** profile (REST `user=` and PowerSync `user_id=`).
- An explicit `weight_unit` in the request, including `null`, is kept.
- PATCH / edits do not rewrite the stored unit if the profile later changes.

The model default remains kg, so the serializer inspects `initial_data` instead of `validated_data`. Checking `validated_data` after DRF applies the model default cannot tell "client omitted the field" from "client sent kg".

Web/Flutter UI pre-selection still belongs in `wger-project/react` and the Flutter app. This repo only owns the API default used when a client omits the field.

## Related Issue(s)

Fixes #2205

See also open PRs #2264 and #2439, which attempt the same feature in `perform_create`. Those stay open; this version avoids the model-default trap, covers workout logs (including PowerSync create), and adds the new-vs-edit cases from the issue discussion.

## Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code has been formatted to avoid unnecessary diffs (`ruff format && isort .`)
- [ ] If the feature is big enough or if there are manual steps needed (deployment changes etc.), write a small writeup in `CHANGELOG.md`

## Testing

```
DJANGO_SETTINGS_MODULE=settings.ci uv run ./manage.py test \
  wger.manager.tests.test_api_weight_unit_default \
  wger.manager.tests.test_log_session_api \
  wger.manager.tests.test_api_ownership_checks \
  wger.manager.tests.test_weight_log \
  wger.manager.tests.test_copy_routine
```

8 new tests plus 39 related existing tests, all passing.